### PR TITLE
feat: 계층적 청킹 로직 구현 및 메타데이터 연동 (#3)

### DIFF
--- a/src/chunking_strategy.py
+++ b/src/chunking_strategy.py
@@ -41,10 +41,16 @@ def create_parent_child_chunks(markdown_text: str, base_metadata: dict) -> list:
     hierarchical_data = []
 
     for doc in parent_docs:
+        # [FIX] MarkdownHeaderTextSplitter는 헤더와 다음 헤더 사이에 텍스트가 없는 경우,
+        # page_content가 비어있는 Document를 생성할 수 있습니다.
+        # 이러한 빈 문서는 건너뛰어 불필요한 데이터 생성을 방지합니다.
+        if not doc.page_content.strip():
+            continue
+
         parent_id = str(uuid.uuid4())
 
-        # Header 2를 우선 적용, 없으면 Header 1 적용 (기본값: "기본 섹션")
-        sec_title = doc.metadata.get("Header 2", doc.metadata.get("Header 1", "기본 섹션"))
+        # 가장 구체적인 헤더부터 제목을 찾습니다 (H3 -> H2 -> H1).
+        sec_title = doc.metadata.get("Header 3") or doc.metadata.get("Header 2") or doc.metadata.get("Header 1") or "기본 섹션"
 
         child_docs = child_splitter.split_text(doc.page_content)
 

--- a/src/chunking_strategy.py
+++ b/src/chunking_strategy.py
@@ -1,12 +1,12 @@
 import json
 import uuid
 from typing import TypedDict, Optional
-# 팀원이 만든 경로 유틸리티 모듈 임포트
+
 from src.utils.paths import PROCESSED_DATA_DIR, ensure_directories
 from langchain_text_splitters import MarkdownHeaderTextSplitter, RecursiveCharacterTextSplitter
 
 
-# 1. 우리가 설계한 메타데이터의 뼈대(타입)를 코드에 정의합니다.
+# 청크 단위 메타데이터 스키마 정의
 class ChunkMetadata(TypedDict):
     doc_id: str
     src_name: str
@@ -17,10 +17,12 @@ class ChunkMetadata(TypedDict):
     parent_id: Optional[str]
 
 
-# 2. 파서(Parser)로부터 넘겨받을 '기본 문서 정보(base_metadata)' 변수를 하나 더 추가로 받습니다.
 def create_parent_child_chunks(markdown_text: str, base_metadata: dict) -> list:
-    """마크다운 텍스트를 입력받아 부모-자식 청크 관계와 메타데이터가 명시된 리스트를 반환합니다."""
+    """
+    마크다운 텍스트를 계층적(Parent-Child)으로 분할하고 메타데이터를 매핑합니다.
+    """
 
+    # 1. 부모 청크: 마크다운 헤더 기준 분할
     headers_to_split_on = [
         ("#", "Header 1"),
         ("##", "Header 2"),
@@ -29,6 +31,7 @@ def create_parent_child_chunks(markdown_text: str, base_metadata: dict) -> list:
     markdown_splitter = MarkdownHeaderTextSplitter(headers_to_split_on=headers_to_split_on)
     parent_docs = markdown_splitter.split_text(markdown_text)
 
+    # 2. 자식 청크: 글자 수 기준 세부 분할
     child_splitter = RecursiveCharacterTextSplitter(
         chunk_size=300,
         chunk_overlap=50,
@@ -40,7 +43,7 @@ def create_parent_child_chunks(markdown_text: str, base_metadata: dict) -> list:
     for doc in parent_docs:
         parent_id = str(uuid.uuid4())
 
-        # 마크다운 헤더(섹션 제목)를 가져옵니다. (없으면 기본값 사용)
+        # Header 2를 우선 적용, 없으면 Header 1 적용 (기본값: "기본 섹션")
         sec_title = doc.metadata.get("Header 2", doc.metadata.get("Header 1", "기본 섹션"))
 
         child_docs = child_splitter.split_text(doc.page_content)
@@ -49,7 +52,7 @@ def create_parent_child_chunks(markdown_text: str, base_metadata: dict) -> list:
         for child_text in child_docs:
             child_id = str(uuid.uuid4())
 
-            # 3. 여기서 자식 청크 하나하나마다 완벽한 메타데이터 이름표를 붙여줍니다!
+            # 자식 청크에 기본 메타데이터 및 계층 ID(parent_id, chunk_id) 병합
             child_metadata: ChunkMetadata = {
                 "doc_id": base_metadata.get("doc_id", "UNKNOWN"),
                 "src_name": base_metadata.get("src_name", "UNKNOWN_FILE"),
@@ -62,10 +65,11 @@ def create_parent_child_chunks(markdown_text: str, base_metadata: dict) -> list:
 
             children_list.append({
                 "child_id": child_id,
-                "metadata": child_metadata,  # 완성된 이름표 부착
+                "metadata": child_metadata,
                 "text": child_text
             })
 
+        # 부모 데이터 구조 완성
         hierarchical_data.append({
             "parent_id": parent_id,
             "parent_text": doc.page_content,
@@ -76,9 +80,10 @@ def create_parent_child_chunks(markdown_text: str, base_metadata: dict) -> list:
 
 
 if __name__ == "__main__":
+    # 필수 디렉토리 확인 및 생성
     ensure_directories()
 
-    # 임시 테스트용 마크다운 데이터
+    # 더미 데이터 세팅 (파서 연동 전 단독 테스트용)
     sample_text = """
     # 신규 입사자 가이드
 
@@ -86,7 +91,6 @@ if __name__ == "__main__":
     정규 출근 시간은 오전 9시이며, 퇴근 시간은 오후 6시입니다.
     """
 
-    # 테스트를 위해 가짜 메타데이터를 하나 만들어 줍니다. (나중에는 파서가 이 정보를 넘겨줍니다)
     dummy_metadata = {
         "doc_id": "HR_001",
         "src_name": "인사규정_2026.pdf",
@@ -94,11 +98,11 @@ if __name__ == "__main__":
         "pg_num": 12
     }
 
-    # 텍스트와 가짜 메타데이터를 같이 집어넣고 실행!
+    # 청킹 파이프라인 실행
     chunking_result = create_parent_child_chunks(sample_text, dummy_metadata)
 
+    # 결과물 JSON 저장
     output_path = PROCESSED_DATA_DIR / "chunked_result.json"
-
     with open(output_path, "w", encoding="utf-8") as f:
         json.dump(chunking_result, f, ensure_ascii=False, indent=4)
 

--- a/src/chunking_strategy.py
+++ b/src/chunking_strategy.py
@@ -1,0 +1,105 @@
+import json
+import uuid
+from typing import TypedDict, Optional
+# 팀원이 만든 경로 유틸리티 모듈 임포트
+from src.utils.paths import PROCESSED_DATA_DIR, ensure_directories
+from langchain_text_splitters import MarkdownHeaderTextSplitter, RecursiveCharacterTextSplitter
+
+
+# 1. 우리가 설계한 메타데이터의 뼈대(타입)를 코드에 정의합니다.
+class ChunkMetadata(TypedDict):
+    doc_id: str
+    src_name: str
+    src_type: Optional[str]
+    pg_num: int
+    sec_title: str
+    chunk_id: str
+    parent_id: Optional[str]
+
+
+# 2. 파서(Parser)로부터 넘겨받을 '기본 문서 정보(base_metadata)' 변수를 하나 더 추가로 받습니다.
+def create_parent_child_chunks(markdown_text: str, base_metadata: dict) -> list:
+    """마크다운 텍스트를 입력받아 부모-자식 청크 관계와 메타데이터가 명시된 리스트를 반환합니다."""
+
+    headers_to_split_on = [
+        ("#", "Header 1"),
+        ("##", "Header 2"),
+        ("###", "Header 3"),
+    ]
+    markdown_splitter = MarkdownHeaderTextSplitter(headers_to_split_on=headers_to_split_on)
+    parent_docs = markdown_splitter.split_text(markdown_text)
+
+    child_splitter = RecursiveCharacterTextSplitter(
+        chunk_size=300,
+        chunk_overlap=50,
+        separators=["\n\n", "\n", " ", ""]
+    )
+
+    hierarchical_data = []
+
+    for doc in parent_docs:
+        parent_id = str(uuid.uuid4())
+
+        # 마크다운 헤더(섹션 제목)를 가져옵니다. (없으면 기본값 사용)
+        sec_title = doc.metadata.get("Header 2", doc.metadata.get("Header 1", "기본 섹션"))
+
+        child_docs = child_splitter.split_text(doc.page_content)
+
+        children_list = []
+        for child_text in child_docs:
+            child_id = str(uuid.uuid4())
+
+            # 3. 여기서 자식 청크 하나하나마다 완벽한 메타데이터 이름표를 붙여줍니다!
+            child_metadata: ChunkMetadata = {
+                "doc_id": base_metadata.get("doc_id", "UNKNOWN"),
+                "src_name": base_metadata.get("src_name", "UNKNOWN_FILE"),
+                "src_type": base_metadata.get("src_type"),
+                "pg_num": base_metadata.get("pg_num", 1),
+                "sec_title": sec_title,
+                "chunk_id": child_id,
+                "parent_id": parent_id
+            }
+
+            children_list.append({
+                "child_id": child_id,
+                "metadata": child_metadata,  # 완성된 이름표 부착
+                "text": child_text
+            })
+
+        hierarchical_data.append({
+            "parent_id": parent_id,
+            "parent_text": doc.page_content,
+            "children": children_list
+        })
+
+    return hierarchical_data
+
+
+if __name__ == "__main__":
+    ensure_directories()
+
+    # 임시 테스트용 마크다운 데이터
+    sample_text = """
+    # 신규 입사자 가이드
+
+    ## 1. 출퇴근 규정
+    정규 출근 시간은 오전 9시이며, 퇴근 시간은 오후 6시입니다.
+    """
+
+    # 테스트를 위해 가짜 메타데이터를 하나 만들어 줍니다. (나중에는 파서가 이 정보를 넘겨줍니다)
+    dummy_metadata = {
+        "doc_id": "HR_001",
+        "src_name": "인사규정_2026.pdf",
+        "src_type": "pdf",
+        "pg_num": 12
+    }
+
+    # 텍스트와 가짜 메타데이터를 같이 집어넣고 실행!
+    chunking_result = create_parent_child_chunks(sample_text, dummy_metadata)
+
+    output_path = PROCESSED_DATA_DIR / "chunked_result.json"
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(chunking_result, f, ensure_ascii=False, indent=4)
+
+    print(f"✅ 메타데이터가 적용된 청킹 완료! 경로: {output_path}")


### PR DESCRIPTION
## 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (feature)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 환경 설정 (setup)

## 주요 작업 내용
- `MarkdownHeaderTextSplitter`와 `RecursiveCharacterTextSplitter`를 활용한 계층적(부모-자식) 청킹 파이프라인 구축
- 청크 간 부모-자식 관계(ID) 및 출처 관리를 위한 `ChunkMetadata` 타입(TypedDict) 스키마 정의
- **[FIX]** 마크다운 파싱 시 내용이 없는 빈 텍스트 구간이 빈 청크 문서로 생성되는 버그 방지 로직 추가
- **[UPDATE]** 섹션 제목(`sec_title`) 매핑 시 가장 구체적인 하위 헤더(H3 -> H2  > H1)를 우선적으로 가져오도록 추출 로직 개선
- 단독 테스트가 가능하도록 `if __name__ == "__main__":` 내부에 더미 데이터를 활용한 실행 및 JSON 저장 로직 구현

## 테스트 결과 / 스크린샷
- 로컬 환경에서 단독 실행 시 에러 없이 통과 확인
- 빈 줄이나 내용 없는 헤더가 입력되었을 때 쓰레기(빈) 데이터가 생성되지 않는 것 확인
- `data/processed/` 폴더 내에 부모-자식 관계와 메타데이터가 정상적으로 맵핑된 `chunked_result.json` 파일 생성 완료

## 셀프 체크리스트
- [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요?
- [x] 불필요한 주석이나 테스트용 print문은 제거했나요? (단독 테스트용 출력문 제외)
- [x] 코드 컨벤션(Linting)을 준수했나요? (Ruff/Black 등)
- [x] 관련 이슈 번호를 연결했나요? ( Closes  #3 )