### PR TITLE
feat: [DB] ChromaDB 연동 및 벡터 스토어 생성 (#19)

### DIFF
--- a/src/main_ui.py
+++ b/src/main_ui.py
@@ -1,0 +1,99 @@
+import streamlit as st
+from pathlib import Path
+
+# --- 1. 페이지 설정 (가장 상단에 위치) ---
+st.set_page_config(
+    page_title="기업 매뉴얼 챗봇",
+    page_icon="🤖",
+    layout="wide"  # 넓은 화면 레이아웃 사용
+)
+
+# --- 2. 초기 세션 상태 설정 (대화 기록 유지용) ---
+if "messages" not in st.session_state:
+    st.session_state.messages = []  # 대화 히스토리를 저장할 리스트
+
+# --- 3. 사이드바 (Sidebar) 구성 ---
+with st.sidebar:
+    st.title("설정 및 관리")
+
+    # [목표 1] 모델 설정
+    st.subheader("모델 설정")
+    selected_model = st.selectbox(
+        "사용할 LLM 모델 선택",
+        ["gpt-3.5-turbo", "gpt-4o", "llama-3-70b"],
+        index=0
+    )
+
+    # [목표 1] 검색 결과 개수(K) 조절 슬라이더
+    st.subheader("검색 설정")
+    k_value = st.slider(
+        "검색할 문서 조각 개수 (K)",
+        min_value=1,
+        max_value=10,
+        value=4,  # 기본값
+        step=1
+    )
+
+    # [목표 3] 파일 업로더 구현 (전처리 파이프라인 연동용)
+    st.subheader("문서 관리")
+    uploaded_files = st.file_uploader(
+        "매뉴얼 파일 업로드 (PDF, DOCX)",
+        type=["pdf", "docx"],
+        accept_multiple_files=True
+    )
+
+    if uploaded_files:
+        st.write(f"총 {len(uploaded_files)}개의 파일이 선택되었습니다.")
+        # 추후 여기에 전처리 파이프라인 연동 로직 추가 예정
+        if st.button("문서 DB화 시작"):
+            with st.spinner("문서를 분석하고 DB에 저장 중입니다..."):
+                # 예시 로직
+                import time
+
+                time.sleep(2)
+                st.success("문서 DB화 완료!")
+
+    st.markdown("---")
+
+    # [목표 1] DB 초기화 버튼 배치
+    st.subheader("시스템 관리")
+    if st.button("벡터 DB 초기화", help="저장된 모든 문서 데이터를 삭제합니다."):
+        st.warning("정말로 초기화하시겠습니까? (로직 미구현)")
+        # 추후 여기에 ChromaDB 초기화 로직 추가 예정
+        st.session_state.messages = []  # 대화 기록도 초기화
+
+# --- 4. 메인 채팅창 (Main Chat) 구성 ---
+st.title("기업 매뉴얼 기반 지능형 챗봇")
+st.markdown(f"현재 모델: **{selected_model}** | 검색 개수(K): **{k_value}**")
+st.markdown("---")
+
+# [목표 2] st.chat_message를 사용한 대화 히스토리 시각화
+# 세션 상태에 저장된 모든 메시지를 순회하며 화면에 출력
+for message in st.session_state.messages:
+    with st.chat_message(message["role"]):
+        st.markdown(message["content"])
+
+# --- 5. 사용자 입력 처리 및 대화 로직 ---
+# 사용자가 채팅 입력창에 입력을 하고 엔터를 치면 실행됨
+if prompt := st.chat_input("궁금한 점을 입력해 주세요."):
+    # 5-1. 사용자 메시지를 화면에 표시
+    with st.chat_message("user"):
+        st.markdown(prompt)
+
+    # 5-2. 사용자 메시지를 세션 상태(히스토리)에 저장
+    st.session_state.messages.append({"role": "user", "content": prompt})
+
+    # 5-3. 챗봇의 답변을 생성하는 로직 (추후 백엔드 엔진 연동)
+    with st.chat_message("assistant"):
+        with st.spinner("생각 중..."):
+            # 예시 답변 (추후 RAG 엔진 답변으로 대체)
+            import time
+
+            time.sleep(1)  # RAG 연동 전 가짜 대기 시간
+
+            # 답변 예시
+            response = f"'{prompt}'에 대한 답변입니다. (추후 RAG 백엔드와 연동되어 실제 매뉴얼 내용을 기반으로 답변합니다.)\n\n**인용 출처:** [운영매뉴얼.pdf, 12p]"
+            st.markdown(response)
+
+    # 5-4. 챗봇의 답변을 세션 상태(히스토리)에 저장
+    st.session_state.messages.append({"role": "assistant", "content": response})

--- a/src/vector_db/chroma_manager.py
+++ b/src/vector_db/chroma_manager.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import logging
 import warnings
 # 경고 숨기기 로직 추가
 os.environ["HF_HUB_DISABLE_SYMLINKS_WARNING"] = "1"
@@ -8,12 +9,11 @@ warnings.filterwarnings("ignore", module="huggingface_hub")
 from typing import List, Dict, Any, Optional
 from pathlib import Path
 
-# 프로젝트 루트를 sys.path에 추가하여 src 모듈 임포트 에러 방지
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.append(str(PROJECT_ROOT))
-# DB 영구 저장 경로 설정 (/.gitignore에 등록된 /vector_db/chroma/ 경로 사용)
-VECTOR_DB_DIR = PROJECT_ROOT / "vector_db" / "chroma"
+# 로깅 설정
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+from src.utils.paths import VECTOR_DB_DIR, ensure_directories
 
 import chromadb
 from chromadb.config import Settings
@@ -40,15 +40,16 @@ class ChromaDBManager:
         """
         ChromaDB 클라이언트 및 컬렉션을 초기화합니다.
         """
-        # 1. 영구 저장(Persistence) 로컬 클라이언트 설정
-        os.makedirs(VECTOR_DB_DIR, exist_ok=True)
-        self.client = chromadb.PersistentClient(path=str(VECTOR_DB_DIR),
-        settings=Settings(anonymized_telemetry=False)
+        # 1. 영구 저장(Persistence) 로컬 클라이언트 설정 및 디렉토리 확인
+        ensure_directories()
+        self.client = chromadb.PersistentClient(
+            path=str(VECTOR_DB_DIR),
+            settings=Settings(anonymized_telemetry=False)
         )
-        
+
         # 2. 커스텀 BGE 임베딩 함수 초기화
         self.embedding_fn = BGEChromaEmbeddingFunction()
-        
+
         # 3. 컬렉션 가져오기 또는 생성
         # BGE-M3 모델은 주로 코사인 유사도(cosine similarity) 검색에 최적화되어 있습니다.
         self.collection = self.client.get_or_create_collection(
@@ -57,7 +58,7 @@ class ChromaDBManager:
             metadata={"hnsw:space": "cosine"}
         )
 
-        print(f"✅ ChromaDB 로드 완료 (컬렉션: {collection_name}, 데이터 개수: {self.collection.count()})")
+        logger.info(f"ChromaDB 로드 완료 (컬렉션: {collection_name}, 데이터 개수: {self.collection.count()})")
 
     def upsert_documents(self, ids: List[str], documents: List[str], metadatas: Optional[List[Dict[str, Any]]] = None):
         """
@@ -65,7 +66,7 @@ class ChromaDBManager:
         기존에 동일한 ID가 존재하면 업데이트(Update)를 수행하여 중복 저장을 방지합니다.
         """
         if not ids or not documents:
-            print("⚠️ 업서트할 문서가 없습니다.")
+            logger.warning("업서트할 문서가 없습니다.")
             return
 
         # ChromaDB 메타데이터에는 None 값이 들어갈 수 없으므로(validation 에러 발생),
@@ -75,11 +76,11 @@ class ChromaDBManager:
             cleaned_metadatas = []
             for meta in metadatas:
                 cleaned = {k: v for k, v in meta.items() if v is not None}
-                
+
                 # ChromaDB는 빈 딕셔너리({}) 삽입을 허용하지 않으므로 더미 키 추가
                 if not cleaned:
                     cleaned = {"_is_empty": True}
-                    
+
                 cleaned_metadatas.append(cleaned)
 
         # Upsert 실행
@@ -88,7 +89,7 @@ class ChromaDBManager:
             documents=documents,
             metadatas=cleaned_metadatas
         )
-        print(f"✅ {len(ids)}개의 문서 청크가 ChromaDB에 성공적으로 업서트되었습니다.")
+        logger.info(f"{len(ids)}개의 문서 청크가 ChromaDB에 성공적으로 업서트되었습니다.")
 
     def query(self, query_texts: List[str], n_results: int = 3) -> dict:
         """
@@ -109,11 +110,11 @@ if __name__ == "__main__":
     # ==========================================
     # 검증 계획 1 & 2 테스트용 스크립트
     # ==========================================
-    print("--- 1. ChromaDB Manager 초기화 ---")
+    logger.info("--- 1. ChromaDB Manager 초기화 ---")
     db_manager = ChromaDBManager(collection_name="test_collection")
     initial_count = db_manager.get_count()
-    
-    print("\n--- 2. 샘플 데이터 준비 및 Upsert ---")
+
+    logger.info("--- 2. 샘플 데이터 준비 및 Upsert ---")
     # 5개의 샘플 텍스트와 메타데이터 준비
     sample_ids = ["chunk_001", "chunk_002", "chunk_003", "chunk_004", "chunk_005"]
     sample_texts = [
@@ -130,28 +131,28 @@ if __name__ == "__main__":
         {"doc_id": "doc_02", "sec_title": "급여 및 복지"},
         {"doc_id": "doc_03", "sec_title": "채용 및 수습"}
     ]
-    
+
     # 첫 번째 업서트 (최초 삽입)
     db_manager.upsert_documents(ids=sample_ids, documents=sample_texts, metadatas=sample_metadatas)
-    
+
     # 두 번째 업서트 (동일 ID로 덮어쓰기 - 중복 데이터 방지 검증)
-    print("\n--- 3. 중복 저장 방지(Upsert) 검증 ---")
+    logger.info("--- 3. 중복 저장 방지(Upsert) 검증 ---")
     db_manager.upsert_documents(ids=sample_ids, documents=sample_texts, metadatas=sample_metadatas)
     final_count = db_manager.get_count()
-    
-    print(f"-> 초기 데이터 개수: {initial_count}")
-    print(f"-> 현재 데이터 개수: {final_count} (동일 ID 재업로드 시 데이터가 중복 증가하지 않음 확인)")
-    
-    print("\n--- 4. 유사도 검색 테스트 ---")
+
+    logger.info(f"-> 초기 데이터 개수: {initial_count}")
+    logger.info(f"-> 현재 데이터 개수: {final_count} (동일 ID 재업로드 시 데이터가 중복 증가하지 않음 확인)")
+
+    logger.info("--- 4. 유사도 검색 테스트 ---")
     queries = ["수습 기간 동안 월급은 어떻게 되나요?", "1년 다니면 휴가 며칠 나와요?"]
     search_results = db_manager.query(query_texts=queries, n_results=2)
-    
+
     for i, query_str in enumerate(queries):
-        print(f"\n[질문]: {query_str}")
+        logger.info(f"[질문]: {query_str}")
         # 반환되는 데이터 구조가 List[List[str]] 형태이므로 인덱싱 접근
         for j in range(len(search_results['documents'][i])):
             doc_text = search_results['documents'][i][j]
             doc_meta = search_results['metadatas'][i][j]
             doc_dist = search_results['distances'][i][j]
             # hnsw:space 가 cosine일 경우, distance 값이 작을수록 (0에 가까울수록) 유사도가 높습니다.
-            print(f"  - 결과 {j+1} (거리: {doc_dist:.4f}): {doc_text} (출처: {doc_meta['sec_title']})")
+            logger.info(f"  - 결과 {j+1} (거리: {doc_dist:.4f}): {doc_text} (출처: {doc_meta['sec_title']})")

--- a/src/vector_db/chroma_manager.py
+++ b/src/vector_db/chroma_manager.py
@@ -1,0 +1,157 @@
+import os
+import sys
+import warnings
+# 경고 숨기기 로직 추가
+os.environ["HF_HUB_DISABLE_SYMLINKS_WARNING"] = "1"
+warnings.filterwarnings("ignore", module="huggingface_hub")
+
+from typing import List, Dict, Any, Optional
+from pathlib import Path
+
+# 프로젝트 루트를 sys.path에 추가하여 src 모듈 임포트 에러 방지
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+# DB 영구 저장 경로 설정 (/.gitignore에 등록된 /vector_db/chroma/ 경로 사용)
+VECTOR_DB_DIR = PROJECT_ROOT / "vector_db" / "chroma"
+
+import chromadb
+from chromadb.config import Settings
+from chromadb.api.types import EmbeddingFunction, Documents, Embeddings
+from src.models.embedder import BGEEmbedder
+
+class BGEChromaEmbeddingFunction(EmbeddingFunction):
+    """
+    ChromaDB 커스텀 임베딩 함수
+    src.models.embedder의 BGEEmbedder를 사용하여 문서를 벡터화합니다.
+    """
+    def __init__(self, model_name: str = 'BAAI/bge-m3'):
+        self.embedder = BGEEmbedder(model_name=model_name)
+
+    def __call__(self, input: Documents) -> Embeddings:
+        # BGEEmbedder.encode는 내부적으로 torch tensor 또는 numpy array를 반환할 수 있으므로
+        # ChromaDB 호환성을 위해 파이썬 내장 기본 리스트 형식(float)으로 변환하여 반환합니다.
+        embeddings = self.embedder.encode(input)
+        return embeddings.tolist()
+
+
+class ChromaDBManager:
+    def __init__(self, collection_name: str = "rag_collection"):
+        """
+        ChromaDB 클라이언트 및 컬렉션을 초기화합니다.
+        """
+        # 1. 영구 저장(Persistence) 로컬 클라이언트 설정
+        os.makedirs(VECTOR_DB_DIR, exist_ok=True)
+        self.client = chromadb.PersistentClient(path=str(VECTOR_DB_DIR),
+        settings=Settings(anonymized_telemetry=False)
+        )
+        
+        # 2. 커스텀 BGE 임베딩 함수 초기화
+        self.embedding_fn = BGEChromaEmbeddingFunction()
+        
+        # 3. 컬렉션 가져오기 또는 생성
+        # BGE-M3 모델은 주로 코사인 유사도(cosine similarity) 검색에 최적화되어 있습니다.
+        self.collection = self.client.get_or_create_collection(
+            name=collection_name,
+            embedding_function=self.embedding_fn,
+            metadata={"hnsw:space": "cosine"}
+        )
+
+        print(f"✅ ChromaDB 로드 완료 (컬렉션: {collection_name}, 데이터 개수: {self.collection.count()})")
+
+    def upsert_documents(self, ids: List[str], documents: List[str], metadatas: Optional[List[Dict[str, Any]]] = None):
+        """
+        문서 청크를 DB에 업서트(Upsert)합니다.
+        기존에 동일한 ID가 존재하면 업데이트(Update)를 수행하여 중복 저장을 방지합니다.
+        """
+        if not ids or not documents:
+            print("⚠️ 업서트할 문서가 없습니다.")
+            return
+
+        # ChromaDB 메타데이터에는 None 값이 들어갈 수 없으므로(validation 에러 발생),
+        # 딕셔너리에서 None 값을 제거하는 전처리 로직 추가 (chunking_strategy.py의 Optional 값 대응)
+        cleaned_metadatas = None
+        if metadatas:
+            cleaned_metadatas = []
+            for meta in metadatas:
+                cleaned = {k: v for k, v in meta.items() if v is not None}
+                
+                # ChromaDB는 빈 딕셔너리({}) 삽입을 허용하지 않으므로 더미 키 추가
+                if not cleaned:
+                    cleaned = {"_is_empty": True}
+                    
+                cleaned_metadatas.append(cleaned)
+
+        # Upsert 실행
+        self.collection.upsert(
+            ids=ids,
+            documents=documents,
+            metadatas=cleaned_metadatas
+        )
+        print(f"✅ {len(ids)}개의 문서 청크가 ChromaDB에 성공적으로 업서트되었습니다.")
+
+    def query(self, query_texts: List[str], n_results: int = 3) -> dict:
+        """
+        주어진 쿼리 텍스트와 가장 유사한 문서를 검색합니다.
+        """
+        results = self.collection.query(
+            query_texts=query_texts,
+            n_results=n_results
+        )
+        return results
+
+    def get_count(self) -> int:
+        """현재 컬렉션에 저장된 총 청크 수를 반환합니다."""
+        return self.collection.count()
+
+
+if __name__ == "__main__":
+    # ==========================================
+    # 검증 계획 1 & 2 테스트용 스크립트
+    # ==========================================
+    print("--- 1. ChromaDB Manager 초기화 ---")
+    db_manager = ChromaDBManager(collection_name="test_collection")
+    initial_count = db_manager.get_count()
+    
+    print("\n--- 2. 샘플 데이터 준비 및 Upsert ---")
+    # 5개의 샘플 텍스트와 메타데이터 준비
+    sample_ids = ["chunk_001", "chunk_002", "chunk_003", "chunk_004", "chunk_005"]
+    sample_texts = [
+        "회사의 정규 출근 시간은 오전 9시이며, 퇴근 시간은 오후 6시입니다.",
+        "연차 휴가는 입사 후 1년이 지나면 15일이 발생합니다.",
+        "식대는 매월 급여와 함께 20만원씩 비과세로 지급됩니다.",
+        "사내 복지 포인트는 매년 1월 1일에 100만 포인트가 지급되며, 복지몰에서 사용 가능합니다.",
+        "신규 입사자는 첫 3개월 동안 수습 기간을 거치며, 수습 기간에도 급여의 100%가 지급됩니다."
+    ]
+    sample_metadatas = [
+        {"doc_id": "doc_01", "sec_title": "출퇴근 규정"},
+        {"doc_id": "doc_01", "sec_title": "휴가 규정"},
+        {"doc_id": "doc_02", "sec_title": "급여 및 복지"},
+        {"doc_id": "doc_02", "sec_title": "급여 및 복지"},
+        {"doc_id": "doc_03", "sec_title": "채용 및 수습"}
+    ]
+    
+    # 첫 번째 업서트 (최초 삽입)
+    db_manager.upsert_documents(ids=sample_ids, documents=sample_texts, metadatas=sample_metadatas)
+    
+    # 두 번째 업서트 (동일 ID로 덮어쓰기 - 중복 데이터 방지 검증)
+    print("\n--- 3. 중복 저장 방지(Upsert) 검증 ---")
+    db_manager.upsert_documents(ids=sample_ids, documents=sample_texts, metadatas=sample_metadatas)
+    final_count = db_manager.get_count()
+    
+    print(f"-> 초기 데이터 개수: {initial_count}")
+    print(f"-> 현재 데이터 개수: {final_count} (동일 ID 재업로드 시 데이터가 중복 증가하지 않음 확인)")
+    
+    print("\n--- 4. 유사도 검색 테스트 ---")
+    queries = ["수습 기간 동안 월급은 어떻게 되나요?", "1년 다니면 휴가 며칠 나와요?"]
+    search_results = db_manager.query(query_texts=queries, n_results=2)
+    
+    for i, query_str in enumerate(queries):
+        print(f"\n[질문]: {query_str}")
+        # 반환되는 데이터 구조가 List[List[str]] 형태이므로 인덱싱 접근
+        for j in range(len(search_results['documents'][i])):
+            doc_text = search_results['documents'][i][j]
+            doc_meta = search_results['metadatas'][i][j]
+            doc_dist = search_results['distances'][i][j]
+            # hnsw:space 가 cosine일 경우, distance 값이 작을수록 (0에 가까울수록) 유사도가 높습니다.
+            print(f"  - 결과 {j+1} (거리: {doc_dist:.4f}): {doc_text} (출처: {doc_meta['sec_title']})")


### PR DESCRIPTION
## 변경 사항 (Checklist)
- [x] 새로운 기능 추가 (feature)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [x] 환경 설정 (setup)

## 주요 작업 내용
- **로컬 ChromaDB 클라이언트 및 컬렉션 구축:** `chromadb.PersistentClient`를 사용하여 로컬 환경에 벡터 스토어를 영구 저장(Persistence)하도록 설정했습니다.
- **커스텀 임베딩 함수 래핑:** `src.models.embedder`의 `BGEEmbedder`를 ChromaDB `EmbeddingFunction`에 래핑하여 텍스트의 자동 벡터화 파이프라인을 구축했습니다.
- **중복 저장 방지(Upsert) 로직 구현:** 문서 ID(예: `chunk_001`)를 기준으로 `upsert`를 사용하여 데이터 중복 증식을 방지했습니다.
- **메타데이터 방어 로직 추가:** ChromaDB의 Validation Error 방지를 위해 `None` 값을 필터링하고 빈 메타데이터는 `{"_is_empty": True}`로 치환하도록 예외 처리를 추가했습니다.
- **(Refactor) 경로 관리 표준화:** 하드코딩된 경로 대신 프로젝트 표준 유틸리티인 `src.utils.paths`의 `VECTOR_DB_DIR` 및 `ensure_directories()`를 적용하여 일관성을 확보했습니다.
- **(Refactor) 로깅 시스템 도입:** 기존의 `print` 문을 모두 제거하고 파이썬 표준 `logging` 모듈을 적용하여 시스템 로그 레벨 관리가 가능하도록 개선했습니다.
- **실행 환경 최적화:** 무한 대기 현상 해결을 위해 텔레메트리(`anonymized_telemetry=False`)를 비활성화하고, `huggingface_hub` Warning을 숨김 처리했습니다.

## 테스트 결과 / 스크린샷
- **영속성(Persistence) 및 Upsert 테스트:**
  - 5개의 샘플 텍스트 저장 후 재실행 시 데이터가 정상 유지됨(초기 데이터 5개 로드).
  - 동일 ID 재업로드 시 데이터가 5개로 유지되며 중복 발생하지 않음.
- **의미 기반 유사도 검색(Semantic Search) 테스트:**
  - "수습 기간 동안 월급은 어떻게 되나요?" -> 1순위: "...수습 기간에도 급여의 100%가 지급됩니다." (거리: 0.2823)
  - 코사인 유사도(Cosine) 기반으로 키워드 불일치 상황에서도 문맥을 정확히 파악함.
- **로깅 테스트:** - 터미널에 타임스탬프와 로그 레벨(INFO/WARNING)이 정상적으로 포맷팅되어 출력됨 확인.

## 셀프 체크리스트
- [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요?
- [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
- [x] 코드 컨벤션(Linting)을 준수했나요? (Ruff/Black 등)
- [x] 관련 이슈 번호를 연결했나요? (Resolves #19)

## 리뷰어에게 한마디
이전 코드 리뷰에서 주신 피드백(경로 표준화 및 로깅 모듈 적용)을 모두 반영하여 코드를 리팩토링했습니다. 
`upsert_documents` 내부의 메타데이터 전처리 로직이 향후 다른 문서 구조와 잘 호환될지, 그리고 로깅 포맷이 다른 모듈들과 잘 어울리는지 확인 부탁드립니다.