### PR TITLE
feat(#53): 거대한 마크다운 표 분할 시 헤더 복제 유지 및 is_table 메타데이터 추가

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,9 @@ tqdm
 # 데이터 파싱 (PDF 및 워드)
 pymupdf
 docx2txt
+unstructured[pdf]
+pandas
+tabulate
 
 # UI 및 환경 설정
 streamlit>=1.55.0

--- a/src/common/constants.py
+++ b/src/common/constants.py
@@ -18,3 +18,4 @@ class MetadataFields:
     SEC_TITLE: Final[str] = "sec_title"
     CONTENT_PREVIEW: Final[str] = "content_preview"
     HEADER_PATH: Final[str] = "header_path"
+    IS_TABLE: Final[str] = "is_table"

--- a/src/common/schema.json
+++ b/src/common/schema.json
@@ -12,6 +12,7 @@
     "chunk_id": "현재 청크의 고유 순번",
     "sec_title": "현재 청크가 속한 가장 인접한 마크다운 섹션 제목",
     "header_path": "마크다운 헤더 전체 계층 경로 (예: 제1장 > 제1조 > 정의)",
-    "content_preview": "디버깅용 텍스트 일부 (선택사항)"
+    "content_preview": "디버깅용 텍스트 일부 (선택사항)",
+    "is_table": "표(Table) 데이터 포함 여부 (True/False)"
   }
 }

--- a/src/common/schema.py
+++ b/src/common/schema.py
@@ -10,6 +10,7 @@ class ChunkMetadata(TypedDict, total=False):
     chunk_id: str
     parent_id: str | None
     header_path: str
+    is_table: bool
 
 
 class ChildChunk(TypedDict):

--- a/src/processing/chunking.py
+++ b/src/processing/chunking.py
@@ -127,9 +127,10 @@ class HierarchicalChunker:
         return protected_text, tables
 
     def _restore_tables(self, text: str, tables: dict[str, str]) -> str:
-        """특수 토큰을 다시 원래 표 데이터로 복원"""
-        for token, table_text in tables.items():
-            text = text.replace(token, table_text)
+        """패딩된 특수 토큰을 다시 원래 표 데이터로 복원"""
+        # 긴 토큰부터 교체하여 부분 일치 문제 방지
+        for token in sorted(tables.keys(), key=len, reverse=True):
+            text = text.replace(token, tables[token])
         return text
 
     def _get_header_path(self, metadata: dict[str, str]) -> str:
@@ -170,13 +171,13 @@ class HierarchicalChunker:
             child_id = f"{parent_id}_c{idx}"
 
             child_metadata_dict: ChunkMetadata = {
-                "source_id": base_metadata.get(MetadataFields.SOURCE_ID, "UNKNOWN"),
-                "src_name": base_metadata.get(MetadataFields.SRC_NAME, "UNKNOWN_FILE"),
-                "doc_type": base_metadata.get(MetadataFields.DOC_TYPE, "markdown"),
-                "pg_num": base_metadata.get(MetadataFields.PG_NUM, 1),
-                "sec_title": base_metadata.get(MetadataFields.SEC_TITLE, "기본 섹션"),
-                "chunk_id": child_id,
-                "parent_id": parent_id,
+                MetadataFields.SOURCE_ID: base_metadata.get(MetadataFields.SOURCE_ID, "UNKNOWN"),
+                MetadataFields.SRC_NAME: base_metadata.get(MetadataFields.SRC_NAME, "UNKNOWN_FILE"),
+                MetadataFields.DOC_TYPE: base_metadata.get(MetadataFields.DOC_TYPE, "markdown"),
+                MetadataFields.PG_NUM: base_metadata.get(MetadataFields.PG_NUM, 1),
+                MetadataFields.SEC_TITLE: base_metadata.get(MetadataFields.SEC_TITLE, "기본 섹션"),
+                MetadataFields.CHUNK_ID: child_id,
+                MetadataFields.PARENT_ID: parent_id,
                 MetadataFields.HEADER_PATH: base_metadata.get(MetadataFields.HEADER_PATH, "기본 섹션"),
                 MetadataFields.IS_TABLE: has_table,
             }
@@ -224,13 +225,13 @@ class HierarchicalChunker:
                     continue
 
                 parent_metadata: ChunkMetadata = {
-                    "source_id": base_metadata.get(MetadataFields.SOURCE_ID, "UNKNOWN"),
-                    "src_name": base_metadata.get(MetadataFields.SRC_NAME, "UNKNOWN_FILE"),
-                    "doc_type": base_metadata.get(MetadataFields.DOC_TYPE, "markdown"),
-                    "pg_num": base_metadata.get(MetadataFields.PG_NUM, 1),
-                    "sec_title": sec_title,
-                    "chunk_id": parent_id,
-                    "parent_id": None,
+                    MetadataFields.SOURCE_ID: base_metadata.get(MetadataFields.SOURCE_ID, "UNKNOWN"),
+                    MetadataFields.SRC_NAME: base_metadata.get(MetadataFields.SRC_NAME, "UNKNOWN_FILE"),
+                    MetadataFields.DOC_TYPE: base_metadata.get(MetadataFields.DOC_TYPE, "markdown"),
+                    MetadataFields.PG_NUM: base_metadata.get(MetadataFields.PG_NUM, 1),
+                    MetadataFields.SEC_TITLE: sec_title,
+                    MetadataFields.CHUNK_ID: parent_id,
+                    MetadataFields.PARENT_ID: None,
                     MetadataFields.HEADER_PATH: header_path,
                 }
 

--- a/src/processing/chunking.py
+++ b/src/processing/chunking.py
@@ -54,26 +54,74 @@ class HierarchicalChunker:
             chunk_size=self.child_chunk_size, chunk_overlap=self.child_chunk_overlap, separators=["\n\n", "\n", " ", ""]
         )
 
+    def _split_markdown_table(self, table_text: str, max_size: int) -> list[str]:
+        """마크다운 표가 max_size를 초과할 경우, 헤더(컬럼)를 유지하며 여러 표로 분할합니다."""
+        lines = table_text.strip().split("\n")
+        # 표의 형태를 갖추지 않았거나 분할할 행이 부족한 경우 원본 반환
+        if len(lines) < 3:
+            return [table_text]
+
+        header = lines[0]
+        separator = lines[1]
+        data_rows = lines[2:]
+
+        # 기본 크기: 헤더 + 구분선 + 개행 문자 길이
+        base_size = len(header) + len(separator) + 2
+
+        chunks = []
+        current_rows = []
+        current_size = base_size
+
+        for row in data_rows:
+            row_size = len(row) + 1
+            if current_size + row_size > max_size and current_rows:
+                chunks.append("\n".join([header, separator] + current_rows))
+                current_rows = [row]
+                current_size = base_size + row_size
+            else:
+                current_rows.append(row)
+                current_size += row_size
+
+        if current_rows:
+            chunks.append("\n".join([header, separator] + current_rows))
+
+        return chunks
+
     def _protect_tables(self, text: str) -> tuple[str, dict[str, str]]:
         """표(Table) 데이터가 청킹 도중 잘리지 않도록 특수 토큰으로 일시 치환"""
         tables = {}
 
-        # [완벽하게 개선된 정규식]
-        # 1. 헤더 줄: 파이프(|)가 1개 이상 존재
-        # 2. 구분선 줄: 반드시 ---|--- 또는 :---:|--- 형태를 띰 (이것이 표라는 확실한 증거)
-        # 3. 데이터 줄: 파이프(|)가 1개 이상 존재하는 줄이 0개 이상 이어짐
         table_pattern = re.compile(
-            r"^[ \t]*\|?.*\|.*\n"  # 1. 헤더 줄
-            r"^[ \t]*\|?[ \t]*[-:]+[ \t]*\|[ \t]*[-:]+.*(?:\n|$)"  # 2. 필수 구분선 줄 (---|---)
-            r"(?:^[ \t]*\|?.*\|.*(?:\n|$))*",  # 3. 데이터 줄
+            r"^[ \t]*\|?.*\|.*\n"
+            r"^[ \t]*\|?[ \t]*[-:]+[ \t]*\|[ \t]*[-:]+.*(?:\n|$)"
+            r"(?:^[ \t]*\|?.*\|.*(?:\n|$))*",
             re.MULTILINE,
         )
 
         def replace_with_token(match):
-            token = f"@@TABLE_{uuid.uuid4().hex}@@"
             table_text = match.group(0).strip()
-            tables[token] = table_text
-            return f"\n\n{token}\n\n"
+
+            # [예외 처리] 표 크기가 청크 사이즈를 초과할 경우 분할 전략 적용
+            if len(table_text) > self.child_chunk_size:
+                split_tables = self._split_markdown_table(table_text, self.child_chunk_size)
+                result_tokens = []
+                for st in split_tables:
+                    token_base = f"@@TABLE_{uuid.uuid4().hex}@@"
+                    # 🚀 핵심 트릭: 분할된 표의 실제 길이만큼 언더바(_)로 패딩을 채워 TextSplitter의 오작동 방지
+                    padding = "_" * max(0, len(st) - len(token_base))
+                    padded_token = token_base + padding
+
+                    tables[padded_token] = st
+                    result_tokens.append(f"\n\n{padded_token}\n\n")
+                return "".join(result_tokens)
+            else:
+                token_base = f"@@TABLE_{uuid.uuid4().hex}@@"
+                # 원본 표의 길이만큼 패딩
+                padding = "_" * max(0, len(table_text) - len(token_base))
+                padded_token = token_base + padding
+
+                tables[padded_token] = table_text
+                return f"\n\n{padded_token}\n\n"
 
         protected_text = table_pattern.sub(replace_with_token, text)
         return protected_text, tables
@@ -112,6 +160,9 @@ class HierarchicalChunker:
 
         children_list: list[ChildChunk] = []
         for idx, child_text in enumerate(merged_docs):
+            # 복원 전 텍스트에 표 토큰이 포함되어 있다면 해당 청크는 표 데이터를 포함함을 의미함
+            has_table = "@@TABLE_" in child_text
+
             restored_text = self._restore_tables(child_text, tables).strip()
             if not restored_text:
                 continue
@@ -127,6 +178,7 @@ class HierarchicalChunker:
                 "chunk_id": child_id,
                 "parent_id": parent_id,
                 MetadataFields.HEADER_PATH: base_metadata.get(MetadataFields.HEADER_PATH, "기본 섹션"),
+                MetadataFields.IS_TABLE: has_table,
             }
 
             children_list.append(

--- a/src/processing/chunking.py
+++ b/src/processing/chunking.py
@@ -75,7 +75,7 @@ class HierarchicalChunker:
         for row in data_rows:
             row_size = len(row) + 1
             if current_size + row_size > max_size and current_rows:
-                chunks.append("\n".join([header, separator] + current_rows))
+                chunks.append("\n".join([header, separator, *current_rows]))
                 current_rows = [row]
                 current_size = base_size + row_size
             else:
@@ -83,7 +83,7 @@ class HierarchicalChunker:
                 current_size += row_size
 
         if current_rows:
-            chunks.append("\n".join([header, separator] + current_rows))
+            chunks.append("\n".join([header, separator, *current_rows]))
 
         return chunks
 

--- a/src/processing/pdf_parser.py
+++ b/src/processing/pdf_parser.py
@@ -1,6 +1,5 @@
 import logging
 from pathlib import Path
-from typing import Any
 
 from langchain_core.documents import Document
 
@@ -20,24 +19,22 @@ class EnhancedPDFParser:
     def parse(self, file_path: str | Path) -> list[Document]:
         try:
             from unstructured.partition.pdf import partition_pdf
-        except ImportError:
+        except ImportError as err:
             raise ImportError(
-                "unstructured 라이브러리가 필요합니다.\n"
-                "설치: pip install unstructured[pdf] pandas"
-            )
+                "unstructured 라이브러리가 필요합니다.\n설치: pip install unstructured[pdf] pandas"
+            ) from err
 
         logger.info(f"파싱 시작: {file_path} (전략: {self.strategy})")
-        
+
         elements = partition_pdf(
             filename=str(file_path),
             strategy=self.strategy,
             infer_table_structure=True,  # 표 구조 추론 활성화
-            extract_images_in_pdf=False, # 1차 목표에 따라 이미지 OCR은 비활성화
+            extract_images_in_pdf=False,  # 1차 목표에 따라 이미지 OCR은 비활성화
         )
 
         docs = []
-        current_section = "기본 섹션"
-        
+
         for el in elements:
             el_type = el.category
             text = el.text
@@ -45,17 +42,14 @@ class EnhancedPDFParser:
             # 표 요소인 경우 마크다운 표 구조로 강제 변환
             if el_type == "Table":
                 html_table = el.metadata.text_as_html if hasattr(el.metadata, "text_as_html") else None
-                if html_table:
-                    text = self._html_to_markdown_table(html_table)
-                else:
-                    text = f"\n| {text} |\n|---|---|\n"
+                text = self._html_to_markdown_table(html_table) if html_table else f"\n| {text} |\n|---|---|\n"
 
             metadata = {
                 "source": str(file_path),
                 "page": el.metadata.page_number if hasattr(el.metadata, "page_number") else 1,
                 "category": el_type,
             }
-            
+
             docs.append(Document(page_content=text, metadata=metadata))
 
         return docs
@@ -64,6 +58,7 @@ class EnhancedPDFParser:
         """HTML 표 데이터를 Pandas를 통해 깔끔한 마크다운으로 변환"""
         try:
             import pandas as pd
+
             dfs = pd.read_html(html)
             if dfs:
                 return "\n" + dfs[0].to_markdown(index=False) + "\n"

--- a/src/processing/pdf_parser.py
+++ b/src/processing/pdf_parser.py
@@ -1,0 +1,72 @@
+import logging
+from pathlib import Path
+from typing import Any
+
+from langchain_core.documents import Document
+
+logger = logging.getLogger(__name__)
+
+
+class EnhancedPDFParser:
+    """
+    Unstructured 라이브러리를 활용하여 표(Table) 구조를 보존하며 PDF를 파싱합니다.
+    - 복잡한 표를 감지하고 HTML을 거쳐 Markdown 표로 변환
+    - yolo 기반 Table Detection 모델 적용 (hi_res 전략 활용)
+    """
+
+    def __init__(self, strategy: str = "hi_res"):
+        self.strategy = strategy
+
+    def parse(self, file_path: str | Path) -> list[Document]:
+        try:
+            from unstructured.partition.pdf import partition_pdf
+        except ImportError:
+            raise ImportError(
+                "unstructured 라이브러리가 필요합니다.\n"
+                "설치: pip install unstructured[pdf] pandas"
+            )
+
+        logger.info(f"파싱 시작: {file_path} (전략: {self.strategy})")
+        
+        elements = partition_pdf(
+            filename=str(file_path),
+            strategy=self.strategy,
+            infer_table_structure=True,  # 표 구조 추론 활성화
+            extract_images_in_pdf=False, # 1차 목표에 따라 이미지 OCR은 비활성화
+        )
+
+        docs = []
+        current_section = "기본 섹션"
+        
+        for el in elements:
+            el_type = el.category
+            text = el.text
+
+            # 표 요소인 경우 마크다운 표 구조로 강제 변환
+            if el_type == "Table":
+                html_table = el.metadata.text_as_html if hasattr(el.metadata, "text_as_html") else None
+                if html_table:
+                    text = self._html_to_markdown_table(html_table)
+                else:
+                    text = f"\n| {text} |\n|---|---|\n"
+
+            metadata = {
+                "source": str(file_path),
+                "page": el.metadata.page_number if hasattr(el.metadata, "page_number") else 1,
+                "category": el_type,
+            }
+            
+            docs.append(Document(page_content=text, metadata=metadata))
+
+        return docs
+
+    def _html_to_markdown_table(self, html: str) -> str:
+        """HTML 표 데이터를 Pandas를 통해 깔끔한 마크다운으로 변환"""
+        try:
+            import pandas as pd
+            dfs = pd.read_html(html)
+            if dfs:
+                return "\n" + dfs[0].to_markdown(index=False) + "\n"
+        except Exception as e:
+            logger.warning(f"HTML -> Markdown 표 변환 실패: {e}")
+        return html

--- a/src/tests/test_table_chunking.py
+++ b/src/tests/test_table_chunking.py
@@ -1,5 +1,3 @@
-import json
-import os
 import sys
 from pathlib import Path
 
@@ -23,7 +21,9 @@ def run_table_chunking_test():
     }
 
     # 의도적으로 자식 청크 사이즈(400자)를 아득히 초과하는 거대한 표 생성
-    massive_table_rows = "\n".join([f"| {i} | 테스트 데이터 {i} | 길이가 꽤 긴 텍스트를 넣어서 용량을 늘립니다. |" for i in range(1, 15)])
+    massive_table_rows = "\n".join(
+        [f"| {i} | 테스트 데이터 {i} | 길이가 꽤 긴 텍스트를 넣어서 용량을 늘립니다. |" for i in range(1, 15)]
+    )
 
     sample_text = f"""# 제1장 총칙
 ## 제3조 (데이터베이스 구조)

--- a/src/tests/test_table_chunking.py
+++ b/src/tests/test_table_chunking.py
@@ -1,0 +1,55 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+# 프로젝트 루트 경로 추가
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from src.common.constants import MetadataFields  # noqa: E402
+from src.processing.chunking import create_parent_child_chunks  # noqa: E402
+
+
+def run_table_chunking_test():
+    print("🚀 [테스트] 거대한 마크다운 표 분할 및 메타데이터 테스트 시작\n")
+
+    dummy_metadata = {
+        MetadataFields.SOURCE_ID: "TEST_TABLE_001",
+        MetadataFields.SRC_NAME: "test_table_manual.md",
+        MetadataFields.DOC_TYPE: "markdown",
+        MetadataFields.PG_NUM: 1,
+    }
+
+    # 의도적으로 자식 청크 사이즈(400자)를 아득히 초과하는 거대한 표 생성
+    massive_table_rows = "\n".join([f"| {i} | 테스트 데이터 {i} | 길이가 꽤 긴 텍스트를 넣어서 용량을 늘립니다. |" for i in range(1, 15)])
+
+    sample_text = f"""# 제1장 총칙
+## 제3조 (데이터베이스 구조)
+아래 표는 시스템의 핵심 데이터베이스 구조를 설명합니다.
+
+| ID | 항목명 | 상세 설명 |
+|---|---|---|
+{massive_table_rows}
+
+표에 대한 설명이 끝났습니다.
+"""
+
+    # 청킹 실행
+    hierarchical_data = create_parent_child_chunks(sample_text, dummy_metadata)
+
+    # 결과 출력
+    for parent_idx, parent in enumerate(hierarchical_data):
+        print(f"📂 Parent Chunk {parent_idx + 1}")
+        for child_idx, child in enumerate(parent["children"]):
+            is_table = child["metadata"].get(MetadataFields.IS_TABLE, False)
+            table_badge = "📊 [표 포함]" if is_table else "📝 [일반 텍스트]"
+
+            print(f"  └─ Child Chunk {child_idx + 1} {table_badge} (길이: {len(child['text'])}자)")
+            print(f"     내용 미리보기:\n{child['text']}")
+            print("-" * 50)
+
+
+if __name__ == "__main__":
+    run_table_chunking_test()


### PR DESCRIPTION
## 변경 사항 (Checklist)
<!-- 이번 PR에서 수행한 핵심 작업을 체크해주세요. -->
- [x] 새로운 기능 추가 (feature)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 환경 설정 (setup)

## 주요 작업 내용
<!-- 무엇을 어떻게 변경했는지 구체적으로 요약해주세요. -->
- **거대한 마크다운 표 분할 및 문맥(헤더) 유지 로직 구현**
  - 단일 청크 크기(`child_chunk_size`)를 초과하는 거대한 표가 들어올 경우, 표의 머리글(Header)과 구분선(`---|---`)을 복제하여 하위 청크들에 각각 삽입하는 `_split_markdown_table` 함수 추가.
  - 이를 통해 LLM이 분할된 표의 뒷부분을 읽더라도 컬럼의 의미(문맥)를 잃지 않도록 개선.
- **TextSplitter 병합 방지용 패딩(Padding) 트릭 적용**
  - 표를 임시 토큰(`@@TABLE_UUID@@`)으로 치환할 때 길이가 짧아져 LangChain의 `TextSplitter`가 여러 표를 하나의 청크로 다시 뭉쳐버리는 문제 해결.
  - 임시 토큰 뒤에 원본 표의 글자 수만큼 언더바(`_`)를 채워 넣는 패딩 처리로 오작동 원천 차단.
- **`is_table` 메타데이터 및 스키마 동기화**
  - 청크에 표 데이터가 포함되어 있는지 식별할 수 있는 `is_table` (bool) 메타데이터 필드 추가.
  - 향후 VectorDB 검색 시 "표 데이터 위주로 검색"하는 필터링 확장을 고려함.
  - `constants.py` 및 `schema.py` 업데이트 완료.
- **마크다운 표 감지 정규식 고도화**
  - 맨 앞 파이프(`|`)가 생략된 표 형식(`|?`)과 명확한 구분선(`[-:]+`)을 조건으로 추가하여 일반 텍스트가 표로 오탐지되는 엣지 케이스 방어.

## 테스트 결과 / 스크린샷
<!-- 실행 결과 로그나 UI 변경 사항을 첨부해주세요. (LangSmith 로그 캡처 등) -->
- `src/tests/test_table_chunking.py`를 통한 거대한 표(794자) 분할 테스트 완료.
- **결과:** 
  1. 399자, 391자로 안전하게 분할됨 (Max 400자 기준 충족)
  2. 분할된 두 번째 청크에도 헤더가 완벽하게 복제됨 확인.
  3. `is_table: True` 메타데이터 정상 할당 확인.

## 셀프 체크리스트
- [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요?
- [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
- [x] 코드 컨벤션(Linting)을 준수했나요? (Ruff/Black 등)
- [x] 관련 이슈 번호를 연결했나요? (Resolves #53)

## 리뷰어에게 한마디
<!-- 리뷰 시 중점적으로 봐주었으면 하는 부분이나 질문을 적어주세요. -->
RAG 시스템에서 문맥 손실을 일으키는 가장 큰 원인 중 하나인 '표(Table) 쪼개짐' 문제를 해결했습니다. 
특히 LangChain의 `TextSplitter`가 임시 토큰을 합쳐버리는 문제를 우회하기 위해 **글자 수만큼 언더바(`_`)로 패딩을 채워 넣는 트릭**을 사용했는데, 이 부분이 안전하게 잘 동작하는지 중점적으로 리뷰해 주시면 감사하겠습니다.