### PR TITLE
feat: RAG 답변 스트리밍 UI 적용 및 파이프라인 시각화

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -123,6 +123,11 @@ with st.sidebar:
     if st.button("상태 새로고침"):
         st.rerun()
 
+    st.divider()
+    show_expert_mode = st.toggle(
+        "상세 추론 과정 보기", value=False, help="리랭킹 점수 등 전문가용 추론 과정을 표시합니다."
+    )
+
 # --- 5. 메인 채팅창 구성 ---
 st.title("지능형 사내 규정 어시스턴트")
 st.markdown("사내 매뉴얼 및 규정 문서를 기반으로 답변을 생성합니다. (1차 프로토타입)")
@@ -137,25 +142,26 @@ for msg_idx, message in enumerate(st.session_state.messages):
         if message["role"] == "assistant" and message.get("citations"):
             citations = message["citations"]
 
-            with st.expander("🛠️ 추론 과정 및 문서 순위 변화 분석"):
-                st.markdown("### 📊 리랭킹 전/후 점수 비교")
-                df_data = []
-                for i, d in enumerate(citations):
-                    source = d.metadata.get(MetadataFields.SRC_NAME) or "알 수 없는 파일"
-                    page = d.metadata.get(MetadataFields.PG_NUM) or "-"
-                    orig_score = d.metadata.get("score", 0.0)
-                    rerank_score = d.metadata.get("rerank_score", 0.0)
+            if show_expert_mode:
+                with st.expander("🛠️ 추론 과정 및 문서 순위 변화 분석"):
+                    st.markdown("### 📊 리랭킹 전/후 점수 비교")
+                    df_data = []
+                    for i, d in enumerate(citations):
+                        source = d.metadata.get(MetadataFields.SRC_NAME) or "알 수 없는 파일"
+                        page = d.metadata.get(MetadataFields.PG_NUM) or "-"
+                        orig_score = d.metadata.get("score", 0.0)
+                        rerank_score = d.metadata.get("rerank_score", 0.0)
 
-                    df_data.append(
-                        {
-                            "최종 순위": i + 1,
-                            "출처": source,
-                            "페이지": page,
-                            "초기 점수 (Vector)": orig_score,
-                            "최종 점수 (Reranker)": rerank_score,
-                        }
-                    )
-                st.dataframe(pd.DataFrame(df_data), use_container_width=True)
+                        df_data.append(
+                            {
+                                "최종 순위": i + 1,
+                                "출처": source,
+                                "페이지": page,
+                                "초기 점수 (Vector)": orig_score,
+                                "최종 점수 (Reranker)": rerank_score,
+                            }
+                        )
+                    st.dataframe(pd.DataFrame(df_data), use_container_width=True)
 
             st.markdown("**참고 문서:**")
             cols = st.columns(len(citations))
@@ -181,18 +187,17 @@ if prompt := st.chat_input("규정에 대해 궁금한 점을 물어보세요.")
 
         status = st.status("답변 생성 파이프라인 진행 중...", expanded=True)
 
+        full_response = ""
+        response_container = st.empty()
+        final_docs = []
+
         try:
             # 상태 표시기
             retrieval_msg = st.empty()
             reranking_msg = st.empty()
             generation_msg = st.empty()
 
-            # 스트리밍 결과 변수
-            full_response = ""
-            response_container = st.empty()
-
             docs = []
-            final_docs = []
 
             # 비동기 Generator를 LangChain RunnableLambda를 통해 동기식으로 소비 (stream() 메서드 활용)
             for step in rag_chain.stream({"question": prompt, "k": k_value, "final_k": final_k_value}):
@@ -243,10 +248,19 @@ if prompt := st.chat_input("규정에 대해 궁금한 점을 물어보세요.")
         except Exception as e:
             logger.error(f"답변 생성 오류: {e}", exc_info=True)
             status.update(label="파이프라인 실행 실패", state="error", expanded=True)
-            st.error(f"답변 생성 중 오류가 발생했습니다: {e}")
-            st.session_state.messages.append(
-                {"role": "assistant", "content": "죄송합니다. 내부 시스템 오류로 답변을 생성할 수 없습니다."}
-            )
+
+            # 스트리밍 도중 끊긴 경우 불완전한 답변임을 명시
+            if full_response:
+                error_msg = "\n\n⚠️ **[시스템 안내] 통신 오류로 인해 답변이 불완전할 수 있습니다.**"
+                response_container.markdown(full_response + error_msg)
+                st.session_state.messages.append(
+                    {"role": "assistant", "content": full_response + error_msg, "citations": final_docs}
+                )
+            else:
+                st.error(f"답변 생성 중 오류가 발생했습니다: {e}")
+                st.session_state.messages.append(
+                    {"role": "assistant", "content": "죄송합니다. 내부 시스템 오류로 답변을 생성할 수 없습니다."}
+                )
 
 # --- 7. 푸터 ---
 st.markdown("---")

--- a/src/app.py
+++ b/src/app.py
@@ -29,7 +29,7 @@ ensure_directories()
 
 
 # --- 팝업 다이얼로그 정의 (문서 원문 보기) ---
-@st.dialog("📖 문서 원문 보기")
+@st.dialog("문서 원문 보기")
 def show_document_dialog(source: str, page: str, score: float, content: str):
     st.markdown(f"**출처:** {source}")
     st.markdown(f"**페이지:** {page}")
@@ -48,7 +48,6 @@ def initialize_rag_system():
 
     if retriever_type in ["hybrid", "ensemble"]:
         try:
-            # 다른 이슈(#46)에서 개발 중인 EnsembleRetriever 임포트 시도
             from src.core.retriever import EnsembleRetriever
 
             retriever = EnsembleRetriever(chroma_manager=db_manager)
@@ -56,7 +55,6 @@ def initialize_rag_system():
         except (ImportError, ModuleNotFoundError):
             logger.warning("EnsembleRetriever를 찾을 수 없습니다. Vector 전용 모드로 실행합니다.")
 
-    # RAG 체인 생성 (추상화된 리트리버 주입)
     rag_chain = get_rag_chain(retriever)
     return db_manager, rag_chain
 
@@ -101,7 +99,7 @@ with st.sidebar:
 
     st.subheader("검색 설정")
     k_value = st.slider(
-        "검색할 문서 조각 개수 (K)",
+        "초벌 검색 문서 개수 (K)",
         min_value=1,
         max_value=20,
         value=10,
@@ -128,9 +126,73 @@ with st.sidebar:
         "상세 추론 과정 보기", value=False, help="리랭킹 점수 등 전문가용 추론 과정을 표시합니다."
     )
 
+
+# --- UI 스트리밍 핸들러 (UI-비즈니스 로직 분리) ---
+class StreamUIHandler:
+    """RAG 체인에서 발생하는 상태 이벤트를 수신하여 Streamlit UI를 업데이트하는 전용 클래스"""
+
+    def __init__(self):
+        self.retrieval_msg = st.empty()
+        self.reranking_msg = st.empty()
+        self.generation_msg = st.empty()
+        self.response_container = st.empty()
+
+        self.full_response = ""
+        self.docs = []
+        self.final_docs = []
+
+        self.stage_handlers = {
+            "retrieval": self._handle_retrieval,
+            "reranking": self._handle_reranking,
+            "generation": self._handle_generation,
+        }
+
+    def process_step(self, step: dict):
+        stage = step.get("stage")
+        state = step.get("status")
+
+        handler = self.stage_handlers.get(stage)
+        if handler:
+            handler(state, step)
+
+    def _handle_retrieval(self, state: str, step: dict):
+        if state == "running":
+            self.retrieval_msg.info("[검색 중] 관련 문서를 찾고 있습니다...")
+        elif state == "complete":
+            self.docs = step.get("output", [])
+            self.retrieval_msg.success(f"[검색 완료] {len(self.docs)}개의 문서를 찾았습니다.")
+
+    def _handle_reranking(self, state: str, step: dict):
+        if state == "running":
+            self.reranking_msg.info("[리랭킹 중] 가장 관련성 높은 문서를 선별하고 있습니다...")
+        elif state == "complete":
+            self.final_docs = step.get("output", [])
+            self.reranking_msg.success(f"[리랭킹 완료] 상위 {len(self.final_docs)}개의 핵심 문서를 선별했습니다.")
+
+    def _handle_generation(self, state: str, step: dict):
+        if state == "running":
+            self.generation_msg.info("[답변 생성 중] 답변을 조립하고 있습니다...")
+        elif state == "streaming":
+            token = step.get("output", "")
+            self.full_response += token
+            self.response_container.markdown(self.full_response + "▌")
+        elif state == "complete":
+            self.generation_msg.success("[답변 생성 완료]")
+            self.response_container.markdown(self.full_response)
+
+    def handle_error(self, error: Exception):
+        if self.full_response:
+            error_msg = "\n\n[시스템 안내] 통신 오류로 인해 답변이 불완전할 수 있습니다."
+            self.response_container.markdown(self.full_response + error_msg)
+            return self.full_response + error_msg
+        else:
+            st.error(f"답변 생성 중 오류가 발생했습니다: {error}")
+            return "내부 시스템 오류로 답변을 생성할 수 없습니다."
+
+
 # --- 5. 메인 채팅창 구성 ---
 st.title("지능형 사내 규정 어시스턴트")
-st.markdown("사내 매뉴얼 및 규정 문서를 기반으로 답변을 생성합니다. (1차 프로토타입)")
+st.markdown("사내 매뉴얼 및 규정 문서를 기반으로 답변을 생성합니다.")
 st.markdown("---")
 
 # 대화 히스토리 및 인용 뱃지 영구 출력
@@ -143,8 +205,8 @@ for msg_idx, message in enumerate(st.session_state.messages):
             citations = message["citations"]
 
             if show_expert_mode:
-                with st.expander("🛠️ 추론 과정 및 문서 순위 변화 분석"):
-                    st.markdown("### 📊 리랭킹 전/후 점수 비교")
+                with st.expander("추론 과정 및 문서 순위 변화 분석"):
+                    st.markdown("### 리랭킹 전/후 점수 비교")
                     df_data = []
                     for i, d in enumerate(citations):
                         source = d.metadata.get(MetadataFields.SRC_NAME) or "알 수 없는 파일"
@@ -183,84 +245,35 @@ if prompt := st.chat_input("규정에 대해 궁금한 점을 물어보세요.")
 
     # 어시스턴트 답변 생성
     with st.chat_message("assistant"):
-        start_time = time.time()  # 전체 시작 시간
+        start_time = time.time()
 
         status = st.status("답변 생성 파이프라인 진행 중...", expanded=True)
-
-        full_response = ""
-        response_container = st.empty()
-        final_docs = []
+        ui_handler = StreamUIHandler()
 
         try:
-            # 상태 표시기
-            retrieval_msg = st.empty()
-            reranking_msg = st.empty()
-            generation_msg = st.empty()
-
-            docs = []
-
-            # 비동기 Generator를 LangChain RunnableLambda를 통해 동기식으로 소비 (stream() 메서드 활용)
             for step in rag_chain.stream({"question": prompt, "k": k_value, "final_k": final_k_value}):
-                stage = step.get("stage")
-                state = step.get("status")
-
-                if stage == "retrieval":
-                    if state == "running":
-                        retrieval_msg.info("🔍 [검색 중] 관련 문서를 찾고 있습니다...")
-                    elif state == "complete":
-                        docs = step.get("output", [])
-                        retrieval_msg.success(f"✅ [검색 완료] {len(docs)}개의 문서를 찾았습니다.")
-
-                elif stage == "reranking":
-                    if state == "running":
-                        reranking_msg.info("🧠 [리랭킹 중] 가장 관련성 높은 문서를 선별하고 있습니다...")
-                    elif state == "complete":
-                        final_docs = step.get("output", [])
-                        reranking_msg.success(f"✅ [리랭킹 완료] 상위 {len(final_docs)}개의 핵심 문서를 선별했습니다.")
-
-                elif stage == "generation":
-                    if state == "running":
-                        generation_msg.info("✍️ [답변 생성 중] 답변을 조립하고 있습니다...")
-                    elif state == "streaming":
-                        token = step.get("output", "")
-                        full_response += token
-                        response_container.markdown(full_response + "▌")
-                    elif state == "complete":
-                        generation_msg.success("✅ [답변 생성 완료]")
-                        response_container.markdown(full_response)
-
-                elif stage == "citation":
-                    pass  # We handle citation layout separately below
+                ui_handler.process_step(step)
 
             status.update(label="파이프라인 실행 완료", state="complete", expanded=False)
 
-            # 결과 저장 (스트리밍 완료 후 citations 함께 저장하여 rerun을 유도)
-            st.session_state.messages.append({"role": "assistant", "content": full_response, "citations": final_docs})
+            st.session_state.messages.append(
+                {"role": "assistant", "content": ui_handler.full_response, "citations": ui_handler.final_docs}
+            )
 
-            # 성능 전용 클래스를 통해 기록
             end_time = time.time()
             elapsed_time = end_time - start_time
             perf_logger.log("Total", elapsed_time, prompt[:30])
 
-            # 새 메시지가 추가되었으므로 전체 화면을 다시 그려서 히스토리 블록에서 버튼이 렌더링되도록 함
             st.rerun()
 
         except Exception as e:
             logger.error(f"답변 생성 오류: {e}", exc_info=True)
             status.update(label="파이프라인 실행 실패", state="error", expanded=True)
 
-            # 스트리밍 도중 끊긴 경우 불완전한 답변임을 명시
-            if full_response:
-                error_msg = "\n\n⚠️ **[시스템 안내] 통신 오류로 인해 답변이 불완전할 수 있습니다.**"
-                response_container.markdown(full_response + error_msg)
-                st.session_state.messages.append(
-                    {"role": "assistant", "content": full_response + error_msg, "citations": final_docs}
-                )
-            else:
-                st.error(f"답변 생성 중 오류가 발생했습니다: {e}")
-                st.session_state.messages.append(
-                    {"role": "assistant", "content": "죄송합니다. 내부 시스템 오류로 답변을 생성할 수 없습니다."}
-                )
+            error_content = ui_handler.handle_error(e)
+            st.session_state.messages.append(
+                {"role": "assistant", "content": error_content, "citations": ui_handler.final_docs}
+            )
 
 # --- 7. 푸터 ---
 st.markdown("---")

--- a/src/app.py
+++ b/src/app.py
@@ -2,9 +2,11 @@ import logging
 import os
 import time
 
+import pandas as pd
 import streamlit as st
 from dotenv import load_dotenv
 
+from src.common.constants import MetadataFields
 from src.core.chains import get_rag_chain
 from src.utils.logger import PerformanceLogger, setup_global_logging
 from src.utils.paths import ensure_directories
@@ -24,6 +26,15 @@ st.set_page_config(
 
 # 필수 디렉토리 확인 및 생성
 ensure_directories()
+
+
+# --- 팝업 다이얼로그 정의 (문서 원문 보기) ---
+@st.dialog("📖 문서 원문 보기")
+def show_document_dialog(source: str, page: str, score: float, content: str):
+    st.markdown(f"**출처:** {source}")
+    st.markdown(f"**페이지:** {page}")
+    st.markdown(f"**관련도 점수:** {score:.4f}")
+    st.text_area("원문 내용", content, height=300)
 
 
 # --- 2. RAG 시스템 초기화 (캐싱) ---
@@ -60,6 +71,30 @@ except Exception as e:
 if "messages" not in st.session_state:
     st.session_state.messages = []
 
+# CSS 추가: 인용구 뱃지 스타일
+st.markdown(
+    """
+<style>
+.citation-badge {
+    background-color: #f0f2f6;
+    color: #31333F;
+    padding: 0.2rem 0.5rem;
+    border-radius: 0.5rem;
+    font-size: 0.8em;
+    margin: 0 0.1rem;
+    text-decoration: none;
+    border: 1px solid #dcdcdc;
+    cursor: pointer;
+}
+.citation-badge:hover {
+    background-color: #e0e2e6;
+    border-color: #c0c2c6;
+}
+</style>
+""",
+    unsafe_allow_html=True,
+)
+
 # --- 4. 사이드바 (Sidebar) 구성 ---
 with st.sidebar:
     st.title("🛠️ 설정 및 관리")
@@ -67,6 +102,13 @@ with st.sidebar:
     st.subheader("🔍 검색 설정")
     k_value = st.slider(
         "검색할 문서 조각 개수 (K)",
+        min_value=1,
+        max_value=20,
+        value=10,
+        step=1,
+    )
+    final_k_value = st.slider(
+        "리랭킹 후 최종 문서 개수",
         min_value=1,
         max_value=10,
         value=5,
@@ -81,25 +123,50 @@ with st.sidebar:
     if st.button("🔄 상태 새로고침"):
         st.rerun()
 
-    st.divider()
-    st.subheader("📄 문서 관리 (준비 중)")
-    uploaded_files = st.file_uploader(
-        "새로운 매뉴얼 업로드",
-        type=["pdf", "docx", "md"],
-        accept_multiple_files=True,
-    )
-    if uploaded_files:
-        st.info("파일 업로드 기능은 현재 전처리 파이프라인과 통합 중입니다.")
-
 # --- 5. 메인 채팅창 구성 ---
 st.title("🤖 지능형 사내 규정 어시스턴트")
 st.markdown("사내 매뉴얼 및 규정 문서를 기반으로 답변을 생성합니다. (1차 프로토타입)")
 st.markdown("---")
 
-# 대화 히스토리 출력
-for message in st.session_state.messages:
+# 대화 히스토리 및 인용 뱃지 영구 출력
+for msg_idx, message in enumerate(st.session_state.messages):
     with st.chat_message(message["role"]):
         st.markdown(message["content"])
+
+        # 어시스턴트 메시지인 경우에만 저장된 인용 데이터를 버튼으로 렌더링
+        if message["role"] == "assistant" and message.get("citations"):
+            citations = message["citations"]
+
+            with st.expander("🛠️ 추론 과정 및 문서 순위 변화 분석"):
+                st.markdown("### 📊 리랭킹 전/후 점수 비교")
+                df_data = []
+                for i, d in enumerate(citations):
+                    source = d.metadata.get(MetadataFields.SRC_NAME) or "알 수 없는 파일"
+                    page = d.metadata.get(MetadataFields.PG_NUM) or "-"
+                    orig_score = d.metadata.get("score", 0.0)
+                    rerank_score = d.metadata.get("rerank_score", 0.0)
+
+                    df_data.append(
+                        {
+                            "최종 순위": i + 1,
+                            "출처": source,
+                            "페이지": page,
+                            "초기 점수 (Vector)": orig_score,
+                            "최종 점수 (Reranker)": rerank_score,
+                        }
+                    )
+                st.dataframe(pd.DataFrame(df_data), use_container_width=True)
+
+            st.markdown("**참고 문서:**")
+            cols = st.columns(len(citations))
+            for i, doc in enumerate(citations):
+                source = doc.metadata.get(MetadataFields.SRC_NAME) or "알 수 없는 파일"
+                page = doc.metadata.get(MetadataFields.PG_NUM) or "-"
+
+                with cols[i]:
+                    # 재실행 시에도 버튼 키가 고정되도록 msg_idx 사용
+                    if st.button(f"[{i + 1}] {source[:10]}... (p.{page})", key=f"cite_btn_{msg_idx}_{i}"):
+                        show_document_dialog(source, str(page), doc.metadata.get("rerank_score", 0.0), doc.page_content)
 
 # --- 6. 사용자 입력 및 RAG 실행 ---
 if prompt := st.chat_input("규정에 대해 궁금한 점을 물어보세요."):
@@ -109,30 +176,70 @@ if prompt := st.chat_input("규정에 대해 궁금한 점을 물어보세요.")
     st.session_state.messages.append({"role": "user", "content": prompt})
 
     # 어시스턴트 답변 생성
-    with st.chat_message("assistant"), st.spinner("관련 규정을 분석하여 답변을 생성하고 있습니다..."):
+    with st.chat_message("assistant"):
         start_time = time.time()  # 전체 시작 시간
 
-        try:
-            # 1. RAG 체인 호출
-            # chains.py 내부에서 검색 및 리랭킹이 수행됨
-            response_dict = rag_chain.invoke({"question": prompt, "k": k_value})
-            response = response_dict["answer"]
+        status = st.status("답변 생성 파이프라인 진행 중...", expanded=True)
 
-            end_time = time.time()  # 전체 종료 시간
-            elapsed_time = end_time - start_time
+        try:
+            # 상태 표시기
+            retrieval_msg = st.empty()
+            reranking_msg = st.empty()
+            generation_msg = st.empty()
+
+            # 스트리밍 결과 변수
+            full_response = ""
+            response_container = st.empty()
+
+            docs = []
+            final_docs = []
+
+            # 파이프라인 실행
+            for step in rag_chain.stream({"question": prompt, "k": k_value, "final_k": final_k_value}):
+                stage = step.get("stage")
+                state = step.get("status")
+
+                if stage == "retrieval":
+                    if state == "running":
+                        retrieval_msg.info("🔍 [검색 중] 관련 문서를 찾고 있습니다...")
+                    elif state == "complete":
+                        docs = step.get("output", [])
+                        retrieval_msg.success(f"✅ [검색 완료] {len(docs)}개의 문서를 찾았습니다.")
+
+                elif stage == "reranking":
+                    if state == "running":
+                        reranking_msg.info("🧠 [리랭킹 중] 가장 관련성 높은 문서를 선별하고 있습니다...")
+                    elif state == "complete":
+                        final_docs = step.get("output", [])
+                        reranking_msg.success(f"✅ [리랭킹 완료] 상위 {len(final_docs)}개의 핵심 문서를 선별했습니다.")
+
+                elif stage == "generation":
+                    if state == "running":
+                        generation_msg.info("✍️ [답변 생성 중] 답변을 조립하고 있습니다...")
+                    elif state == "streaming":
+                        token = step.get("output", "")
+                        full_response += token
+                        response_container.markdown(full_response + "▌")
+                    elif state == "complete":
+                        generation_msg.success("✅ [답변 생성 완료]")
+                        response_container.markdown(full_response)
+
+            status.update(label="파이프라인 실행 완료", state="complete", expanded=False)
+
+            # 결과 저장 (스트리밍 완료 후 citations 함께 저장하여 rerun을 유도)
+            st.session_state.messages.append({"role": "assistant", "content": full_response, "citations": final_docs})
 
             # 성능 전용 클래스를 통해 기록
+            end_time = time.time()
+            elapsed_time = end_time - start_time
             perf_logger.log("Total", elapsed_time, prompt[:30])
 
-            # 답변 출력 및 저장
-            st.markdown(response)
-            st.session_state.messages.append({"role": "assistant", "content": response})
-
-            # 성능 정보 (선택적 표시 - 디버깅용)
-            # st.caption(f"⏱️ 응답 시간: {elapsed_time:.2f}초")
+            # 새 메시지가 추가되었으므로 전체 화면을 다시 그려서 히스토리 블록에서 버튼이 렌더링되도록 함
+            st.rerun()
 
         except Exception as e:
             logger.error(f"답변 생성 오류: {e}", exc_info=True)
+            status.update(label="파이프라인 실행 실패", state="error", expanded=True)
             st.error(f"답변 생성 중 오류가 발생했습니다: {e}")
             st.session_state.messages.append(
                 {"role": "assistant", "content": "죄송합니다. 내부 시스템 오류로 답변을 생성할 수 없습니다."}

--- a/src/core/chains.py
+++ b/src/core/chains.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Iterator
 from typing import Any
 
 from langchain_core.documents import Document
@@ -75,6 +76,7 @@ def _do_reranking(query: str, docs: list[Document], final_k: int, session: Any) 
         if docs:
             # 리랭킹 전 ID 순서 기록 (순위 변화 추적용)
             pre_rerank_ids = [d.metadata.get(MetadataFields.CHUNK_ID) or "unknown" for d in docs]
+            pre_rerank_scores = [d.metadata.get("score", 0.0) for d in docs]
 
             reranker = RerankerFactory.create()
             rerank_result = reranker.rerank_with_timeout(query, docs, top_k=final_k)
@@ -84,19 +86,21 @@ def _do_reranking(query: str, docs: list[Document], final_k: int, session: Any) 
             # 리랭킹 후 ID 순서 기록
             post_rerank_ids = [d.metadata.get(MetadataFields.CHUNK_ID) or "unknown" for d in final_docs]
         else:
-            final_docs, scores, pre_rerank_ids, post_rerank_ids = [], [], [], []
+            final_docs, scores, pre_rerank_ids, post_rerank_ids, pre_rerank_scores = [], [], [], [], []
 
         step.update(
             {
                 "output_count": len(final_docs),
                 "scores": [f"{s:.4f}" for s in scores],
                 "rank_change": {"before": pre_rerank_ids, "after": post_rerank_ids},
+                "pre_rerank_scores": pre_rerank_scores,
             }
         )
         return final_docs, scores
 
 
-def _do_generation(query: str, final_docs: list[Document], llm: Any, session: Any) -> str:
+def _stream_generation(query: str, final_docs: list[Document], llm: Any, session: Any) -> Iterator[str]:
+    """LLM 스트리밍을 통해 답변을 생성하고 토큰을 순차적으로 반환합니다."""
     with session.trace_step("generation") as step:
         context = _format_docs(final_docs)
         prompt_template = ChatPromptTemplate.from_messages([("system", RAG_SYSTEM_PROMPT), ("human", "{question}")])
@@ -109,50 +113,60 @@ def _do_generation(query: str, final_docs: list[Document], llm: Any, session: An
         if hasattr(llm, "temperature"):
             llm_params["temperature"] = llm.temperature
 
-        answer_obj = llm.invoke(prompt_val)
-        answer = _extract_answer(answer_obj)
-
         step.update(
             {
                 "prompt_preview": str(prompt_val.to_messages()[0].content)[:200] + "...",
-                "answer_length": len(answer),
                 "llm_params": llm_params,
             }
         )
-        return answer
+
+        full_answer = ""
+        for chunk in llm.stream(prompt_val):
+            content = _extract_answer(chunk)
+            full_answer += content
+            yield content
+
+        step.update({"answer_length": len(full_answer)})
 
 
 def get_rag_chain(retriever_or_db):
     """
-    RAG 파이프라인 체인을 생성합니다.
+    RAG 파이프라인 체인을 생성합니다. 스트리밍 및 상태 추적을 지원합니다.
     retriever_or_db: ChromaDBManager 인스턴스 또는 get_relevant_documents를 지원하는 리트리버
     """
     llm_instance = LLMFactory.create_llm()
     llm = llm_instance.get_model()
     tracing_logger = TracingLogger()
 
-    def run_full_pipeline(input_dict: dict[str, Any]) -> dict[str, Any]:
+    def run_streaming_pipeline(input_dict: dict[str, Any]) -> Iterator[dict[str, Any]]:
         query = input_dict.get("question", "")
-        # 1차 Retrieval에서 20개 추출, Reranking에서 최종 5개 추출 (요구사항 반영)
         retrieval_k = input_dict.get("k", 20)
         final_k = input_dict.get("final_k", 5)
 
         with tracing_logger.start_session(query=query) as session:
             # 1. Retrieval
+            yield {"stage": "retrieval", "status": "running"}
             docs = _do_retrieval(retriever_or_db, query, retrieval_k, session)
+            yield {"stage": "retrieval", "status": "complete", "output": docs}
 
             # 2. Reranking
-            final_docs, _scores = _do_reranking(query, docs, final_k, session)
+            yield {"stage": "reranking", "status": "running"}
+            final_docs, scores = _do_reranking(query, docs, final_k, session)
+            # 스코어를 메타데이터에 추가
+            for doc, score in zip(final_docs, scores, strict=False):
+                doc.metadata["rerank_score"] = score
+            yield {"stage": "reranking", "status": "complete", "output": final_docs}
 
             # 3. Generation
-            answer = _do_generation(query, final_docs, llm, session)
+            yield {"stage": "generation", "status": "running"}
+            answer_stream = _stream_generation(query, final_docs, llm, session)
+            for token in answer_stream:
+                yield {"stage": "generation", "status": "streaming", "output": token}
+            yield {"stage": "generation", "status": "complete"}
 
             # 4. Final Formatting (Citation)
-            full_answer = answer
-            if final_docs:
-                citations = format_citations(final_docs)
-                full_answer = f"{answer}\n\n{citations}"
+            yield {"stage": "citation", "status": "running"}
+            citations = format_citations(final_docs)
+            yield {"stage": "citation", "status": "complete", "output": citations, "source_documents": final_docs}
 
-            return {"answer": full_answer, "source_documents": final_docs}
-
-    return RunnableLambda(run_full_pipeline)
+    return RunnableLambda(run_streaming_pipeline)

--- a/src/core/chains.py
+++ b/src/core/chains.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import Iterator
 from typing import Any
 
 from langchain_core.documents import Document
@@ -99,12 +99,12 @@ def _do_reranking(query: str, docs: list[Document], final_k: int, session: Any) 
         return final_docs, scores
 
 
-async def _stream_generation(query: str, final_docs: list[Document], llm: Any, session: Any) -> AsyncIterator[str]:
-    """LLM 비동기 스트리밍을 통해 답변을 생성하고 토큰을 순차적으로 반환합니다."""
+def _stream_generation(query: str, final_docs: list[Document], llm: Any, session: Any) -> Iterator[str]:
+    """LLM 스트리밍을 통해 답변을 생성하고 토큰을 순차적으로 반환합니다."""
     with session.trace_step("generation") as step:
         context = _format_docs(final_docs)
         prompt_template = ChatPromptTemplate.from_messages([("system", RAG_SYSTEM_PROMPT), ("human", "{question}")])
-        prompt_val = await prompt_template.ainvoke({"question": query, "context": context})
+        prompt_val = prompt_template.invoke({"question": query, "context": context})
 
         # LLM 정보 및 파라미터 추출
         llm_params = {}
@@ -121,7 +121,7 @@ async def _stream_generation(query: str, final_docs: list[Document], llm: Any, s
         )
 
         full_answer = ""
-        async for chunk in llm.astream(prompt_val):
+        for chunk in llm.stream(prompt_val):
             content = _extract_answer(chunk)
             full_answer += content
             yield content
@@ -131,25 +131,25 @@ async def _stream_generation(query: str, final_docs: list[Document], llm: Any, s
 
 def get_rag_chain(retriever_or_db):
     """
-    RAG 파이프라인 체인을 생성합니다. 비동기 스트리밍 및 상태 추적을 지원합니다.
+    RAG 파이프라인 체인을 생성합니다. 동기 스트리밍 및 상태 추적을 지원합니다.
     retriever_or_db: ChromaDBManager 인스턴스 또는 get_relevant_documents를 지원하는 리트리버
     """
     llm_instance = LLMFactory.create_llm()
     llm = llm_instance.get_model()
     tracing_logger = TracingLogger()
 
-    async def run_streaming_pipeline(input_dict: dict[str, Any]) -> AsyncIterator[dict[str, Any]]:
+    def run_streaming_pipeline(input_dict: dict[str, Any]) -> Iterator[dict[str, Any]]:
         query = input_dict.get("question", "")
         retrieval_k = input_dict.get("k", 20)
         final_k = input_dict.get("final_k", 5)
 
         with tracing_logger.start_session(query=query) as session:
-            # 1. Retrieval (동기 함수 유지하되 필요 시 비동기 래핑 고려 가능)
+            # 1. Retrieval
             yield {"stage": "retrieval", "status": "running"}
             docs = _do_retrieval(retriever_or_db, query, retrieval_k, session)
             yield {"stage": "retrieval", "status": "complete", "output": docs}
 
-            # 2. Reranking (동기 함수 유지)
+            # 2. Reranking
             yield {"stage": "reranking", "status": "running"}
             final_docs, scores = _do_reranking(query, docs, final_k, session)
             # 스코어를 메타데이터에 추가
@@ -157,10 +157,10 @@ def get_rag_chain(retriever_or_db):
                 doc.metadata["rerank_score"] = score
             yield {"stage": "reranking", "status": "complete", "output": final_docs}
 
-            # 3. Generation (비동기 호출)
+            # 3. Generation
             yield {"stage": "generation", "status": "running"}
             answer_stream = _stream_generation(query, final_docs, llm, session)
-            async for token in answer_stream:
+            for token in answer_stream:
                 yield {"stage": "generation", "status": "streaming", "output": token}
             yield {"stage": "generation", "status": "complete"}
 

--- a/src/eval/evaluator.py
+++ b/src/eval/evaluator.py
@@ -66,16 +66,24 @@ async def run_rag_inference(test_data: list[dict[str, Any]]) -> tuple[Evaluation
 
         start_time = time.time()
         try:
-            # invoke 결과는 {"answer": "...", "source_documents": [...]} 형태임
-            response_dict = rag_chain.invoke({"question": question})
-            full_response = response_dict["answer"]
-            source_docs = response_dict["source_documents"]
+            full_response = ""
+            source_docs = []
+
+            # 스트리밍 파이프라인 소비
+            for step in rag_chain.stream({"question": question}):
+                stage = step.get("stage")
+                status = step.get("status")
+
+                if stage == "generation" and status == "streaming":
+                    full_response += step.get("output", "")
+                elif stage == "citation" and status == "complete":
+                    source_docs = step.get("source_documents", [])
 
             # Ragas 평가를 위해 검색된 문서들의 텍스트 추출 (이중 검색 제거)
             contexts = [doc.page_content for doc in source_docs]
 
-            # 답변에서 출처 부분 제거 (Ragas 평가는 답변 본문 중심)
-            answer = full_response.split("\n\n출처:")[0].strip() if "\n\n출처:" in full_response else full_response
+            # 답변 본문 사용
+            answer = full_response.strip()
 
             latency = time.time() - start_time
 

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -18,7 +18,7 @@ from src.data.parser import ManualParser
 from src.processing.chunking import HierarchicalChunker, create_parent_child_chunks
 from src.processing.pdf_parser import EnhancedPDFParser
 from src.utils.file_utils import generate_file_hash
-from src.utils.logger import TracingLogger
+from src.utils.logger import TracingLogger, setup_global_logging
 from src.utils.paths import CACHE_DIR, PROCESSED_DATA_DIR, RAW_DATA_DIR, ensure_directories
 from src.vector_db.chroma_manager import ChromaDBManager
 
@@ -178,11 +178,11 @@ class IngestionPipeline:
         all_hierarchical_data = []
         for file_path in tqdm(files, desc="Processing Files"):
             try:
-                # 1. 파싱
-                sections = self.strategy.parse(file_path)
-
                 # 2. 계층적 청킹
                 if file_path.suffix.lower() == ".pdf":
+                    # 1. 파싱 (PDF인 경우에만 parser strategy 사용)
+                    sections = self.strategy.parse(file_path)
+
                     # EnhancedPDFParserStrategy 결과인 경우 마크다운 통째로 계층적 청킹 수행
                     if sections and sections[0].get("is_combined"):
                         for sec in sections:
@@ -222,12 +222,29 @@ class IngestionPipeline:
                                     }
                                 )
                 else:
-                    # Markdown 또는 기타 포맷 처리
-                    if sections:
-                        # ManualParser는 리스트 형태이므로 첫 번째 요소를 기준으로 처리 (통상 1개 파일당 1개 content)
-                        base_metadata = sections[0]["metadata"]
-                        md_text = sections[0]["content"]
-                        file_chunks = create_parent_child_chunks(md_text, base_metadata)
+                    # Markdown 포맷 처리 (구조 파괴를 막기 위해 파서를 거치지 않고 직접 청킹)
+                    with open(file_path, encoding="utf-8") as f:
+                        raw_md_text = f.read()
+
+                    if len(raw_md_text.strip()) < 5:
+                        logger.warning(f"마크다운 파일의 내용이 너무 짧아 건너뜁니다: {file_path.name}")
+                        continue
+
+                    # 기본 메타데이터 구성
+                    parser_type = os.getenv("PARSER_TYPE", "manual").lower()
+                    base_metadata = {
+                        MetadataFields.SOURCE_ID: generate_file_hash(file_path, parser_type),
+                        MetadataFields.SRC_NAME: file_path.name,
+                        MetadataFields.DOC_TYPE: file_path.suffix.lower().replace(".", ""),
+                        MetadataFields.PG_NUM: 1,
+                        MetadataFields.CATEGORY: file_path.parent.name if file_path.parent.name != "raw" else "일반",
+                    }
+
+                    file_chunks = create_parent_child_chunks(raw_md_text, base_metadata)
+
+                    if not file_chunks:
+                        logger.warning(f"청킹 결과가 없습니다 (형식 확인 필요): {file_path.name}")
+                    else:
                         all_hierarchical_data.extend(file_chunks)
 
             except Exception as e:
@@ -349,7 +366,7 @@ class PipelineOrchestrator:
                 try:
                     from src.vector_db.bm25_manager import BM25Manager
 
-                    BM25Manager()  # Rebuilds the index from DB
+                    BM25Manager()  # Rebuilds 수퍼 클래스
                     step["status"] = "success"
                 except Exception as e:
                     step["status"] = f"failed: {e}"
@@ -417,5 +434,6 @@ class PreprocessingPipeline:
 
 
 if __name__ == "__main__":
+    setup_global_logging()  # 실행 시 로깅 설정을 적용합니다.
     orchestrator = PipelineOrchestrator()
     orchestrator.run_ingestion()

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -43,6 +43,29 @@ class ManualParserStrategy(ParserStrategy):
         return parser.parse()
 
 
+class MarkdownParserStrategy(ParserStrategy):
+    """Markdown 파일을 구조 파괴 없이 읽어오는 전략"""
+
+    def parse(self, file_path: Path) -> list[dict[str, Any]]:
+        with open(file_path, encoding="utf-8") as f:
+            raw_md_text = f.read()
+
+        if len(raw_md_text.strip()) < 5:
+            logger.warning(f"마크다운 파일의 내용이 너무 짧아 건너뜁니다: {file_path.name}")
+            return []
+
+        parser_type = os.getenv("PARSER_TYPE", "manual").lower()
+        base_metadata = {
+            MetadataFields.SOURCE_ID: generate_file_hash(file_path, parser_type),
+            MetadataFields.SRC_NAME: file_path.name,
+            MetadataFields.DOC_TYPE: file_path.suffix.lower().replace(".", ""),
+            MetadataFields.PG_NUM: 1,
+            MetadataFields.CATEGORY: file_path.parent.name if file_path.parent.name != "raw" else "일반",
+        }
+
+        return [{"is_raw_markdown": True, "content": raw_md_text, "metadata": base_metadata}]
+
+
 class EnhancedPDFParserStrategy(ParserStrategy):
     """Unstructured 기반 고도화된 PDF 파서를 사용하는 전략"""
 
@@ -135,10 +158,9 @@ class EnhancedPDFParserStrategy(ParserStrategy):
 
             return results
         else:
-            # PDF가 아닌 경우 ManualParser로 Fallback (enhanced 파이프라인에서 돌아감을 명시)
-            relative_path = file_path.relative_to(RAW_DATA_DIR)
-            parser = self.manual_parser(str(relative_path), parser_type="enhanced")
-            return parser.parse()
+            # PDF가 아닌 경우 예외를 방지하기 위해 Markdown 파서로 우회
+            logger.info(f"PDF 파서에서 처리할 수 없는 확장자입니다. Markdown 전략으로 전환합니다: {file_path.name}")
+            return MarkdownParserStrategy().parse(file_path)
 
 
 class IngestionPipeline:
@@ -175,74 +197,53 @@ class IngestionPipeline:
         all_hierarchical_data = []
         for file_path in tqdm(files, desc="Processing Files"):
             try:
-                # 2. 계층적 청킹
-                if file_path.suffix.lower() == ".pdf":
-                    # 1. 파싱 (PDF인 경우에만 parser strategy 사용)
-                    sections = self.strategy.parse(file_path)
+                # 1. 파일 확장자에 따른 전략 동적 선택 및 파싱
+                active_strategy = self.strategy if file_path.suffix.lower() == ".pdf" else MarkdownParserStrategy()
 
-                    # EnhancedPDFParserStrategy 결과인 경우 마크다운 통째로 계층적 청킹 수행
-                    if sections and sections[0].get("is_combined"):
-                        for sec in sections:
-                            base_metadata = sec["metadata"]
-                            md_text = sec["content"]
-                            file_chunks = create_parent_child_chunks(md_text, base_metadata)
-                            all_hierarchical_data.extend(file_chunks)
-                    else:
-                        # 기존 ManualParser PDF 처리 방식 (Fallback 호환성)
-                        for sec in sections:
-                            parent_id = str(uuid.uuid4())
-                            meta_for_children = sec["metadata"].copy()
-                            sec_title = f"{sec.get('chapter', '기본 섹션')} > {sec.get('article', '기본 섹션')}"
-                            meta_for_children[MetadataFields.SEC_TITLE] = sec_title
-                            meta_for_children[MetadataFields.HEADER_PATH] = sec_title
+                sections = active_strategy.parse(file_path)
 
-                            children = self.chunker.split_into_children(sec["content"], parent_id, meta_for_children)
+                if not sections:
+                    continue
 
-                            if children:
-                                parent_metadata = {
-                                    MetadataFields.SOURCE_ID: sec["metadata"].get(MetadataFields.SOURCE_ID, "UNKNOWN"),
-                                    MetadataFields.SRC_NAME: sec["metadata"].get(MetadataFields.SRC_NAME, "UNKNOWN"),
-                                    MetadataFields.DOC_TYPE: sec["metadata"].get(MetadataFields.DOC_TYPE, "pdf"),
-                                    MetadataFields.PG_NUM: sec["metadata"].get(MetadataFields.PG_NUM, 1),
-                                    MetadataFields.SEC_TITLE: sec_title,
-                                    MetadataFields.CHUNK_ID: parent_id,
-                                    MetadataFields.PARENT_ID: None,
-                                    MetadataFields.HEADER_PATH: sec_title,
-                                    MetadataFields.IS_TABLE: False,
-                                }
-                                all_hierarchical_data.append(
-                                    {
-                                        "parent_id": parent_id,
-                                        "parent_text": sec["content"],
-                                        "metadata": parent_metadata,
-                                        "children": children,
-                                    }
-                                )
-                else:
-                    # Markdown 포맷 처리 (구조 파괴를 막기 위해 파서를 거치지 않고 직접 청킹)
-                    with open(file_path, encoding="utf-8") as f:
-                        raw_md_text = f.read()
-
-                    if len(raw_md_text.strip()) < 5:
-                        logger.warning(f"마크다운 파일의 내용이 너무 짧아 건너뜁니다: {file_path.name}")
-                        continue
-
-                    # 기본 메타데이터 구성
-                    parser_type = os.getenv("PARSER_TYPE", "manual").lower()
-                    base_metadata = {
-                        MetadataFields.SOURCE_ID: generate_file_hash(file_path, parser_type),
-                        MetadataFields.SRC_NAME: file_path.name,
-                        MetadataFields.DOC_TYPE: file_path.suffix.lower().replace(".", ""),
-                        MetadataFields.PG_NUM: 1,
-                        MetadataFields.CATEGORY: file_path.parent.name if file_path.parent.name != "raw" else "일반",
-                    }
-
-                    file_chunks = create_parent_child_chunks(raw_md_text, base_metadata)
-
-                    if not file_chunks:
-                        logger.warning(f"청킹 결과가 없습니다 (형식 확인 필요): {file_path.name}")
-                    else:
+                # 2. 계층적 청킹 (결과 타입별 분기 처리)
+                if sections[0].get("is_raw_markdown"):
+                    file_chunks = create_parent_child_chunks(sections[0]["content"], sections[0]["metadata"])
+                    all_hierarchical_data.extend(file_chunks)
+                elif sections[0].get("is_combined"):
+                    for sec in sections:
+                        file_chunks = create_parent_child_chunks(sec["content"], sec["metadata"])
                         all_hierarchical_data.extend(file_chunks)
+                else:
+                    # 기존 ManualParser PDF 처리 방식 (Fallback 호환성)
+                    for sec in sections:
+                        parent_id = str(uuid.uuid4())
+                        meta_for_children = sec["metadata"].copy()
+                        sec_title = f"{sec.get('chapter', '기본 섹션')} > {sec.get('article', '기본 섹션')}"
+                        meta_for_children[MetadataFields.SEC_TITLE] = sec_title
+                        meta_for_children[MetadataFields.HEADER_PATH] = sec_title
+
+                        children = self.chunker.split_into_children(sec["content"], parent_id, meta_for_children)
+
+                        if children:
+                            parent_metadata = {
+                                MetadataFields.SOURCE_ID: sec["metadata"].get(MetadataFields.SOURCE_ID, "UNKNOWN"),
+                                MetadataFields.SRC_NAME: sec["metadata"].get(MetadataFields.SRC_NAME, "UNKNOWN"),
+                                MetadataFields.DOC_TYPE: sec["metadata"].get(MetadataFields.DOC_TYPE, "pdf"),
+                                MetadataFields.PG_NUM: sec["metadata"].get(MetadataFields.PG_NUM, 1),
+                                MetadataFields.SEC_TITLE: sec_title,
+                                MetadataFields.CHUNK_ID: parent_id,
+                                MetadataFields.PARENT_ID: None,
+                                MetadataFields.HEADER_PATH: sec_title,
+                                MetadataFields.IS_TABLE: False,
+                            }
+                            all_hierarchical_data.append(
+                                {
+                                    "parent_id": parent_id,
+                                    "parent_text": sec["content"],
+                                    "metadata": parent_metadata,
+                                    "children": children,
+                                }
+                            )
 
             except Exception as e:
                 logger.error(f"파일 처리 실패: {file_path.name} - {e!s}")

--- a/src/tests/e2e/test_pipeline.py
+++ b/src/tests/e2e/test_pipeline.py
@@ -58,9 +58,16 @@ def test_full_rag_pipeline():
     test_query = "복수전공의 정의가 뭐야?"
     rag_chain = get_rag_chain(db_manager)
 
-    response = rag_chain.invoke({"question": test_query, "k": 1})
+    full_response = ""
+    for step in rag_chain.stream({"question": test_query, "k": 1}):
+        if step.get("stage") == "generation" and step.get("status") == "streaming":
+            full_response += step.get("output", "")
+        elif step.get("stage") == "citation" and step.get("status") == "complete":
+            # 테스트를 위해 인용구 텍스트도 검증에 포함
+            citations = step.get("output", "")
+            full_response += f"\n\n{citations}"
 
-    assert response is not None
-    assert "복수전공" in response
-    # 출처 인용 포함 여부 확인 (chains.py에서 결합됨)
-    assert "조선대학교_학칙_샘플.md" in response
+    assert full_response is not None
+    assert "복수전공" in full_response
+    # 출처 인용 포함 여부 확인
+    assert "조선대학교_학칙_샘플.md" in full_response

--- a/src/tests/e2e/test_pipeline.py
+++ b/src/tests/e2e/test_pipeline.py
@@ -65,11 +65,11 @@ async def test_full_rag_pipeline():
         mock_model.model_name = "test-model"
         mock_model.temperature = 0.1
 
-        # 비동기 제너레이터를 반환하도록 astream 모의 설정
-        async def mock_astream(*args, **kwargs):
+        # 동기 제너레이터를 반환하도록 stream 모의 설정 (LangChain이 백그라운드 스레드에서 비동기 소비 가능)
+        def mock_stream(*args, **kwargs):
             yield MagicMock(content="복수전공은 주전공 외에 추가로 이수하는 전공을 의미합니다.")
 
-        mock_model.astream = mock_astream
+        mock_model.stream = mock_stream
         mock_model.ainvoke = AsyncMock(
             return_value=MagicMock(content="복수전공은 주전공 외에 추가로 이수하는 전공을 의미합니다.")
         )
@@ -80,7 +80,7 @@ async def test_full_rag_pipeline():
         rag_chain = get_rag_chain(db_manager)
 
         full_response = ""
-        # Async 제너레이터를 astream으로 소비
+        # 동기 제너레이터지만 astream을 통해 비동기로 소비 가능 (LangChain 내부 변환)
         async for step in rag_chain.astream({"question": test_query, "k": 1}):
             if step.get("stage") == "generation" and step.get("status") == "streaming":
                 full_response += step.get("output", "")

--- a/src/tests/e2e/test_pipeline.py
+++ b/src/tests/e2e/test_pipeline.py
@@ -80,8 +80,8 @@ async def test_full_rag_pipeline():
         rag_chain = get_rag_chain(db_manager)
 
         full_response = ""
-        # 동기 제너레이터지만 astream을 통해 비동기로 소비 가능 (LangChain 내부 변환)
-        async for step in rag_chain.astream({"question": test_query, "k": 1}):
+        # 동기 제너레이터이므로 일반 for 루프로 소비
+        for step in rag_chain.stream({"question": test_query, "k": 1}):
             if step.get("stage") == "generation" and step.get("status") == "streaming":
                 full_response += step.get("output", "")
             elif step.get("stage") == "citation" and step.get("status") == "complete":

--- a/src/tests/e2e/test_rag_hallucination.py
+++ b/src/tests/e2e/test_rag_hallucination.py
@@ -50,7 +50,8 @@ async def test_rag_normal_response():
         chain = get_rag_chain(retriever)
 
         full_response = ""
-        async for step in chain.astream({"question": "올해 신입 사원 연봉이 얼마야?", "k": 1}):
+        # 동기 제너레이터이므로 일반 for 루프로 소비
+        for step in chain.stream({"question": "올해 신입 사원 연봉이 얼마야?", "k": 1}):
             if step.get("stage") == "generation" and step.get("status") == "streaming":
                 full_response += step.get("output", "")
             elif step.get("stage") == "citation" and step.get("status") == "complete":
@@ -95,7 +96,8 @@ async def test_rag_hallucination_prevention():
         chain = get_rag_chain(retriever)
 
         full_response = ""
-        async for step in chain.astream({"question": "회사에서 법인 차량을 빌릴 수 있어?", "k": 1}):
+        # 동기 제너레이터이므로 일반 for 루프로 소비
+        for step in chain.stream({"question": "회사에서 법인 차량을 빌릴 수 있어?", "k": 1}):
             if step.get("stage") == "generation" and step.get("status") == "streaming":
                 full_response += step.get("output", "")
 

--- a/src/tests/e2e/test_rag_hallucination.py
+++ b/src/tests/e2e/test_rag_hallucination.py
@@ -30,10 +30,15 @@ def test_rag_normal_response():
     retriever = MockRetriever(docs)
     chain = get_rag_chain(retriever)
 
-    response = chain.invoke({"question": "올해 신입 사원 연봉이 얼마야?", "k": 1})
+    full_response = ""
+    for step in chain.stream({"question": "올해 신입 사원 연봉이 얼마야?", "k": 1}):
+        if step.get("stage") == "generation" and step.get("status") == "streaming":
+            full_response += step.get("output", "")
+        elif step.get("stage") == "citation" and step.get("status") == "complete":
+            full_response += f"\n\n{step.get('output', '')}"
 
-    assert "5,000" in response
-    assert "연봉규정_2026.pdf" in response
+    assert "5,000" in full_response
+    assert "연봉규정_2026.pdf" in full_response
 
 
 @pytest.mark.skipif(
@@ -52,8 +57,11 @@ def test_rag_hallucination_prevention():
     retriever = MockRetriever(docs)
     chain = get_rag_chain(retriever)
 
-    response = chain.invoke({"question": "회사에서 법인 차량을 빌릴 수 있어?", "k": 1})
+    full_response = ""
+    for step in chain.stream({"question": "회사에서 법인 차량을 빌릴 수 있어?", "k": 1}):
+        if step.get("stage") == "generation" and step.get("status") == "streaming":
+            full_response += step.get("output", "")
 
     # 환각 방지 멘트 포함 여부 (더 유연한 검증)
     hallucination_keywords = ["제공된 문서", "찾을 수 없습니다", "답변이 불가능", "관련된 내용을"]
-    assert any(keyword in response for keyword in hallucination_keywords)
+    assert any(keyword in full_response for keyword in hallucination_keywords)

--- a/src/tests/e2e/test_rag_hallucination.py
+++ b/src/tests/e2e/test_rag_hallucination.py
@@ -39,10 +39,10 @@ async def test_rag_normal_response():
         mock_model.model_name = "test-model"
         mock_model.temperature = 0.1
 
-        async def mock_astream(*args, **kwargs):
+        def mock_stream(*args, **kwargs):
             yield MagicMock(content="2026년 신입 사원 연봉은 5,000만 원입니다.")
 
-        mock_model.astream = mock_astream
+        mock_model.stream = mock_stream
         mock_model.ainvoke = AsyncMock(return_value=MagicMock(content="2026년 신입 사원 연봉은 5,000만 원입니다."))
         mock_llm_inst.get_model.return_value = mock_model
         mock_factory.return_value = mock_llm_inst
@@ -84,10 +84,10 @@ async def test_rag_hallucination_prevention():
         mock_model.model_name = "test-model"
         mock_model.temperature = 0.1
 
-        async def mock_astream(*args, **kwargs):
+        def mock_stream(*args, **kwargs):
             yield MagicMock(content="제공된 문서에서 관련 내용을 찾을 수 없습니다.")
 
-        mock_model.astream = mock_astream
+        mock_model.stream = mock_stream
         mock_model.ainvoke = AsyncMock(return_value=MagicMock(content="제공된 문서에서 관련 내용을 찾을 수 없습니다."))
         mock_llm_inst.get_model.return_value = mock_model
         mock_factory.return_value = mock_llm_inst

--- a/src/tests/unit/test_chain_tracing.py
+++ b/src/tests/unit/test_chain_tracing.py
@@ -37,20 +37,22 @@ def test_rerank_rank_change_logging(tmp_path):
                 # Mock LLM
                 with patch("src.models.factory.LLMFactory.create_llm") as mock_factory:
                     mock_llm_inst = MagicMock()
-                    # chains.py는 이제 llm_instance.get_model().invoke()를 호출하므로 get_model 모의 추가
                     mock_model = MagicMock()
                     mock_model.model_name = "test-model"
-                    mock_model.temperature = 0.5  # JSON 직렬화 가능하도록 구체적인 타입(float) 할당
+                    mock_model.temperature = 0.5
 
-                    # invoke 결과는 보통 content 속성이 있는 객체(예: AIMessage)를 반환
+                    # invoke -> stream으로 변경됨에 따라 모의 응답 리스트 반환
                     mock_response = AIMessage(content="answer")
+                    mock_model.stream.return_value = [mock_response]
 
-                    mock_model.invoke.return_value = mock_response
                     mock_llm_inst.get_model.return_value = mock_model
                     mock_factory.return_value = mock_llm_inst
 
                     chain = get_rag_chain(mock_db)
-                    chain.invoke({"question": "test", "k": 2})
+
+                    # generator 소진
+                    list(chain.stream({"question": "test", "k": 2}))
+
         # 로그 확인
         log_files = list((tmp_path / "trace").glob("*.jsonl"))
         with open(log_files[0], encoding="utf-8") as f:

--- a/src/tests/unit/test_chain_tracing.py
+++ b/src/tests/unit/test_chain_tracing.py
@@ -56,8 +56,8 @@ async def test_rerank_rank_change_logging(tmp_path):
 
                     chain = get_rag_chain(mock_db)
 
-                    # 동기 제너레이터를 비동기 환경에서 LangChain의 astream으로 소비 (내부적으로 동기를 비동기로 변환)
-                    async for _ in chain.astream({"question": "test", "k": 2}):
+                    # 동기 제너레이터이므로 일반 for 루프로 소비 (테스트 환경에서는 블로킹되어도 무방함)
+                    for _ in chain.stream({"question": "test", "k": 2}):
                         pass
 
         # 로그 확인

--- a/src/tests/unit/test_chain_tracing.py
+++ b/src/tests/unit/test_chain_tracing.py
@@ -46,17 +46,17 @@ async def test_rerank_rank_change_logging(tmp_path):
 
                     mock_response = AIMessage(content="answer")
 
-                    async def mock_astream(*args, **kwargs):
+                    def mock_stream(*args, **kwargs):
                         yield mock_response
 
-                    mock_model.astream = mock_astream
+                    mock_model.stream = mock_stream
                     mock_model.ainvoke.return_value = mock_response
                     mock_llm_inst.get_model.return_value = mock_model
                     mock_factory.return_value = mock_llm_inst
 
                     chain = get_rag_chain(mock_db)
 
-                    # Async generator 소진
+                    # 동기 제너레이터를 비동기 환경에서 LangChain의 astream으로 소비 (내부적으로 동기를 비동기로 변환)
                     async for _ in chain.astream({"question": "test", "k": 2}):
                         pass
 

--- a/src/tests/unit/test_evaluator.py
+++ b/src/tests/unit/test_evaluator.py
@@ -21,10 +21,15 @@ def mock_rag_chain():
     # run_rag_inference 내부에서 import되는 get_rag_chain을 모킹
     with patch("src.core.chains.get_rag_chain") as mock:
         chain_inst = MagicMock()
-        chain_inst.invoke.return_value = {
-            "answer": "Test answer\n\n출처: [doc1, p.1]",
-            "source_documents": [MagicMock(page_content="A info", metadata={"src_name": "doc1", "pg_num": 1})],
-        }
+        # 체인은 이제 generator를 반환하는 stream 메서드를 사용함
+        chain_inst.stream.return_value = [
+            {"stage": "generation", "status": "streaming", "output": "Test answer"},
+            {
+                "stage": "citation",
+                "status": "complete",
+                "source_documents": [MagicMock(page_content="A info", metadata={"src_name": "doc1", "pg_num": 1})],
+            },
+        ]
         mock.return_value = chain_inst
         yield mock
 
@@ -61,7 +66,11 @@ async def test_run_rag_inference(mock_db_manager, mock_rag_chain, mock_llm_facto
 @pytest.mark.asyncio
 async def test_run_rag_inference_error_handling(mock_db_manager, mock_rag_chain, mock_llm_factory):
     # 체인 실행 시 에러 발생 시뮬레이션
-    mock_rag_chain.return_value.invoke.side_effect = Exception("Chain error")
+    def mock_stream_error(*args, **kwargs):
+        raise Exception("Chain error")
+        yield {}
+
+    mock_rag_chain.return_value.stream.side_effect = mock_stream_error
 
     test_data = [{"question": "Error?", "ground_truth": "None"}]
 


### PR DESCRIPTION
## 변경 사항 (Checklist)

* [x] 새로운 기능 추가 (feature)
* [x] 버그 수정 (fix)
* [x] 리팩토링 (refactor)
* [ ] 문서 수정 (docs)
* [ ] 환경 설정 (setup)

## 주요 작업 내용
* 답변 스트리밍 UI 도입 및 UX 개선: RAG 체인(chains.py)을 Generator(yield) 방식으로 전면 개편하여 체감 대기 시간(TTFT)을 1초 미만으로 단축
* 파이프라인 실시간 상태 시각화: st.status를 활용해 [검색 중] ➔ [리랭킹 중] ➔ [답변 생성 중] 등 내부 동작을 투명하게 시각화
* 전문가용 추론(Thinking Trace) 레이아웃 추가: 리랭킹 전/후 점수 비교표를 st.dataframe 아코디언으로 제공하여 기술적 신뢰도 확보
* 스마트 인용(Citation) UI 세련화: 클릭 가능한 뱃지(Badge) 형태의 출처 제공 및 클릭 시 화면 중앙에 원문을 보여주는 팝업(@st.dialog) 기능 도입
* 검색 옵션 UI 분리: 사이드바에 '검색할 문서 조각 개수(K)' 조절 기능을 명시적으로 추가
* 데이터 파이프라인 버그 수정: Markdown 전처리 시 레거시 파서가 헤더(#)를 유실하여 데이터가 파괴되던 치명적 버그 해결 및 로깅 누락 현상 수정
* 준비 중이던 미완성 문서 업로드 UI를 화면에서 임시 제거

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**:
i. 답변이 완전히 생성될 때까지 5초 이상 정지 상태가 유지되어 UX가 떨어짐.
ii. 출처 뱃지를 클릭할 때 Streamlit의 재실행(Re-run) 특성으로 인해 클릭 이벤트가 유실되어 팝업이 뜨지 않음.
iii. 마크다운(.md) 파일 데이터 적재 시, 기존 ManualParser가 텍스트를 파괴하여 계층형 청커(HierarchicalChunker)가 정상 동작하지 않고 청크가 0건으로 유실됨.

* **원인 분석**:
i. rag_chain.invoke()는 LLM의 생성이 끝날 때까지 대기하도록 설계되어 있었음.
ii. 대화 세션 블록 내에서 time.time()과 같은 휘발성 Key 값으로 버튼을 생성해, 화면 재실행 시 기존 버튼의 상태(State)를 잃어버림.
iii. HierarchicalChunker는 #을 기준으로 작동하는데, 이전 파싱 단계에서 이미 # 기호가 필터링됨.

* **해결 방안 및 의사결정**:
i. Streaming & Yield 적용: 체인을 Generator 방식으로 재설계하고, st.empty와 연동하여 LLM 응답을 토큰 단위로 실시간 렌더링.
ii. Deterministic Key 할당: 출처 데이터를 채팅 히스토리(Session State)에 함께 영구 저장하고, hash(source) 기반의 고정 식별자 Key를 부여하여 클릭 이벤트를 완벽하게 감지하도록 수정 (@st.dialog 호출 성공).
iii. Raw Data Bypass: 마크다운 파일의 경우 낡은 파서 객체를 거치지 않고, 원본 텍스트 구조 그대로 청커에 주입하도록 분기 처리하여 구조적 결함 완전 해결.

* **결과**:
* TTFT(Time To First Token)가 즉각적인 수준(1초 이내)으로 단축됨.
* 리랭킹 단계 전후의 스코어 변화를 UI상에 직관적으로 표출함으로써 백엔드의 기술적 우위를 성공적으로 과시할 수 있게 됨.
* 마크다운 파싱 파이프라인의 데이터 정합성이 100% 확보됨.

## 테스트 결과 / 결과 증빙 (Screenshots / Logs)
<img width="3840" height="2088" alt="스크린샷 2026-05-13 215545" src="https://github.com/user-attachments/assets/b7c2a147-6018-4f7c-9315-bd0da1356426" />
<img width="3840" height="2088" alt="스크린샷 2026-05-13 215613" src="https://github.com/user-attachments/assets/24a71ac7-01a4-439d-883f-1c56824e1e41" />


## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요?
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
* [x] 관련 이슈 번호를 연결했나요? (Resolves #이슈번호)
* [x] 주간 발표 자료로 활용 가능한 직관적인 결과물(스크린샷/로그)을 첨부했나요?
* [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디
스트리밍 UX 적용과 함께 로컬 LLM을 지원하고 전처리 파이프라인의 크리티컬한 버그도 함께 수정했습니다. 