### PR TITLE
perf(bm25): scipy sparse matrix 기반 인덱스 전환으로 메모리 최적화 (#109)

### DIFF
--- a/src/tests/integration/test_bm25.py
+++ b/src/tests/integration/test_bm25.py
@@ -6,7 +6,6 @@ import pytest
 from src.vector_db.bm25_index import BM25PlusIndex
 from src.vector_db.bm25_manager import BM25Manager
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/src/tests/integration/test_bm25.py
+++ b/src/tests/integration/test_bm25.py
@@ -1,41 +1,59 @@
 import json
 
+import numpy as np
 import pytest
 
+from src.vector_db.bm25_index import BM25PlusIndex
 from src.vector_db.bm25_manager import BM25Manager
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_manager(tmp_path, json_files: dict) -> BM25Manager:
+    """tmp_path 안에 데이터 디렉토리와 캐시 디렉토리를 분리하여 BM25Manager를 생성함."""
+    data_dir = tmp_path / "processed"
+    data_dir.mkdir()
+    cache_dir = tmp_path / "bm25_cache"
+
+    for filename, payload in json_files.items():
+        with open(data_dir / filename, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+
+    return BM25Manager(data_dir=data_dir, cache_dir=cache_dir)
 
 
 @pytest.fixture
 def bm25_manager(tmp_path):
-    """테스트용 임시 디렉토리 및 데이터 파일 세팅"""
-    data_dir = tmp_path / "processed"
-    data_dir.mkdir()
-
-    # 파일 1: 조선대 관련
-    data1 = [
+    """기본 검색 기능 테스트용 매니저"""
+    return _make_manager(
+        tmp_path,
         {
-            "content": "조선대학교 휴학 신청 기간은 3월부터입니다.",
-            "metadata": {"src_name": "manual1.pdf", "pg_num": 1},
-        }
-    ]
-    with open(data_dir / "data1.json", "w", encoding="utf-8") as f:
-        json.dump(data1, f)
-
-    # 파일 2: 복학 및 장학금 관련
-    data2 = [
-        {
-            "content": "복학 신청 방법은 홈페이지를 참조하세요.",
-            "metadata": {"src_name": "manual2.pdf", "pg_num": 2},
+            "data1.json": [
+                {
+                    "content": "조선대학교 휴학 신청 기간은 3월부터입니다.",
+                    "metadata": {"src_name": "manual1.pdf", "pg_num": 1},
+                }
+            ],
+            "data2.json": [
+                {
+                    "content": "복학 신청 방법은 홈페이지를 참조하세요.",
+                    "metadata": {"src_name": "manual2.pdf", "pg_num": 2},
+                },
+                {
+                    "content": "성적 장학금 지급 기준 안내입니다.",
+                    "metadata": {"src_name": "manual2.pdf", "pg_num": 3},
+                },
+            ],
         },
-        {
-            "content": "성적 장학금 지급 기준 안내입니다.",
-            "metadata": {"src_name": "manual2.pdf", "pg_num": 3},
-        },
-    ]
-    with open(data_dir / "data2.json", "w", encoding="utf-8") as f:
-        json.dump(data2, f)
+    )
 
-    return BM25Manager(data_dir=data_dir)
+
+# ---------------------------------------------------------------------------
+# 기존 기능 검증
+# ---------------------------------------------------------------------------
 
 
 def test_multi_file_loading(bm25_manager):
@@ -64,30 +82,113 @@ def test_no_result(bm25_manager):
 
 def test_hierarchical_loading(tmp_path):
     """계층형 데이터(children, parent_text)가 평탄화되어 모두 로드되는지 확인"""
-    data_dir = tmp_path / "hierarchical_processed"
-    data_dir.mkdir()
-
-    # 실제 데이터와 유사한 계층 구조
-    data = [
+    manager = _make_manager(
+        tmp_path,
         {
-            "parent_id": "p1",
-            "parent_text": "보안 규정 서문입니다.",
-            "metadata": {"source_id": "doc1", "src_name": "security.pdf"},
-            "children": [
+            "hierarchical.json": [
                 {
-                    "chunk_id": "c1",
-                    "text": "제1조 목적: 정보 자산 보호.",
-                    "metadata": {"parent_id": "p1"},
+                    "parent_id": "p1",
+                    "parent_text": "보안 규정 서문입니다.",
+                    "metadata": {"source_id": "doc1", "src_name": "security.pdf"},
+                    "children": [
+                        {
+                            "chunk_id": "c1",
+                            "text": "제1조 목적: 정보 자산 보호.",
+                            "metadata": {"parent_id": "p1"},
+                        }
+                    ],
                 }
-            ],
-        }
-    ]
+            ]
+        },
+    )
 
-    with open(data_dir / "hierarchical.json", "w", encoding="utf-8") as f:
-        json.dump(data, f)
-
-    manager = BM25Manager(data_dir=data_dir)
     contents = [doc["content"] for doc in manager.corpus_data]
-
     assert "제1조 목적: 정보 자산 보호." in contents
     assert "보안 규정 서문입니다." in contents
+
+
+def test_corpus_fields_slim(tmp_path):
+    """corpus_data에 content·metadata만 보존되는지 확인 (불필요 필드 제거 검증)"""
+    manager = _make_manager(
+        tmp_path,
+        {
+            "slim.json": [
+                {
+                    "chunk_id": "c1",
+                    "text": "필드 슬림화 테스트 문서입니다.",
+                    "parent_text": "삭제되어야 할 필드",
+                    "extra_field": "삭제되어야 할 필드",
+                    "metadata": {"src_name": "slim.pdf"},
+                }
+            ]
+        },
+    )
+
+    assert len(manager.corpus_data) == 1
+    doc = manager.corpus_data[0]
+
+    # 보존되어야 할 필드
+    assert "content" in doc
+    assert "metadata" in doc
+    assert doc["chunk_id"] == "c1"  # RRF 중복 제거용 최상위 chunk_id
+
+    # 제거되어야 할 불필요 필드
+    assert "text" not in doc
+    assert "parent_text" not in doc
+    assert "extra_field" not in doc
+
+
+# ---------------------------------------------------------------------------
+# 직렬화 라운드트립 검증
+# ---------------------------------------------------------------------------
+
+
+def test_cache_roundtrip(tmp_path):
+    """인덱스를 저장한 뒤 재로드해도 검색 결과가 동일한지 확인"""
+    manager = _make_manager(
+        tmp_path,
+        {
+            "rt.json": [
+                {"content": "캐시 저장 및 로드 테스트입니다.", "metadata": {}},
+                {"content": "전혀 다른 주제의 문서입니다.", "metadata": {}},
+            ]
+        },
+    )
+
+    query = "캐시"
+    results_before = manager.get_top_n(query, n=1, return_scores=True)
+    assert len(results_before) == 1
+
+    # 캐시에서 재로드
+    manager2 = BM25Manager(data_dir=tmp_path / "processed", cache_dir=tmp_path / "bm25_cache")
+    results_after = manager2.get_top_n(query, n=1, return_scores=True)
+
+    assert len(results_after) == 1
+    assert results_before[0]["content"] == results_after[0]["content"]
+    assert abs(results_before[0]["_bm25_score"] - results_after[0]["_bm25_score"]) < 1e-4
+
+
+def test_bm25_index_serialization(tmp_path):
+    """BM25PlusIndex.save / load 라운드트립: 점수 배열이 동일한지 확인"""
+    corpus = [["휴학", "신청", "기간"], ["복학", "신청", "홈페이지"], ["장학금", "지급", "기준"]]
+    index = BM25PlusIndex()
+    index.build(corpus)
+
+    cache_dir = tmp_path / "idx_cache"
+    index.save(cache_dir)
+
+    loaded = BM25PlusIndex.load(cache_dir)
+
+    query_tokens = ["신청"]
+    scores_orig = index.get_scores(query_tokens)
+    scores_loaded = loaded.get_scores(query_tokens)
+
+    np.testing.assert_allclose(scores_orig, scores_loaded, rtol=1e-5)
+
+
+def test_return_scores_flag(bm25_manager):
+    """return_scores=True 시 _bm25_score 및 _rank 필드가 포함되는지 확인"""
+    results = bm25_manager.get_top_n("휴학", n=2, return_scores=True)
+    assert all("_bm25_score" in r for r in results)
+    assert all("_rank" in r for r in results)
+    assert results[0]["_rank"] == 1

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -26,7 +26,8 @@ EVAL_LOGS_DIR = (LOGS_DIR / "eval").resolve()
 # 4. 설정 및 사전 파일 경로
 SYNONYMS_FILE = (BASE_DIR / "src" / "common" / "synonyms.json").resolve()
 CACHE_DIR = (BASE_DIR / ".cache").resolve()
-BM25_CACHE_FILE = CACHE_DIR / "bm25_index.pkl"
+BM25_CACHE_FILE = CACHE_DIR / "bm25_index.pkl"  # legacy — kept for reference only
+BM25_CACHE_DIR = CACHE_DIR / "bm25_v2"
 CROSS_ENCODER_CACHE_DIR = CACHE_DIR / "cross-encoder"
 
 

--- a/src/vector_db/bm25_index.py
+++ b/src/vector_db/bm25_index.py
@@ -2,7 +2,7 @@
 Memory-efficient BM25Plus index using scipy sparse matrices.
 
 Replaces rank_bm25.BM25Plus:
-  - TF matrix  : scipy CSC sparse (n_docs × vocab_size)  — replaces list[dict] doc_freqs
+  - TF matrix  : scipy CSC sparse (n_docs x vocab_size)  — replaces list[dict] doc_freqs
   - IDF        : numpy float32 array (vocab_size,)        — replaces Python dict
   - doc_len    : numpy float32 array (n_docs,)            — replaces list[int]
   - vocab      : plain dict[str, int]                     — word → column index
@@ -99,7 +99,7 @@ class BM25PlusIndex:
 
         Uses CSC column slicing to process only non-zero (doc, term) pairs,
         avoiding a full toarray() dense expansion that would spike to
-        O(n_docs × n_query_terms) memory regardless of corpus sparsity.
+        O(n_docs x n_query_terms) memory regardless of corpus sparsity.
         """
         if self.tf_matrix is None or not query_tokens:
             return np.zeros(self.corpus_size, dtype=np.float32)

--- a/src/vector_db/bm25_index.py
+++ b/src/vector_db/bm25_index.py
@@ -154,12 +154,12 @@ class BM25PlusIndex:
         obj = cls()
         obj.tf_matrix = load_npz(str(cache_dir / _TF_FILE))
 
-        arr = np.load(str(cache_dir / _ARRAYS_FILE))
-        obj.idf = arr["idf"]
-        obj.doc_len = arr["doc_len"]
-        p = arr["params"]
-        obj.k1, obj.b, obj.delta, obj.avgdl = float(p[0]), float(p[1]), float(p[2]), float(p[3])
-        obj.corpus_size = int(p[4])
+        with np.load(str(cache_dir / _ARRAYS_FILE)) as arr:
+            obj.idf = arr["idf"]
+            obj.doc_len = arr["doc_len"]
+            p = arr["params"]
+            obj.k1, obj.b, obj.delta, obj.avgdl = float(p[0]), float(p[1]), float(p[2]), float(p[3])
+            obj.corpus_size = int(p[4])
 
         with open(cache_dir / _VOCAB_FILE, encoding="utf-8") as f:
             obj.vocab = json.load(f)

--- a/src/vector_db/bm25_index.py
+++ b/src/vector_db/bm25_index.py
@@ -1,0 +1,152 @@
+"""
+Memory-efficient BM25Plus index using scipy sparse matrices.
+
+Replaces rank_bm25.BM25Plus:
+  - TF matrix  : scipy CSR sparse (n_docs × vocab_size)  — replaces list[dict] doc_freqs
+  - IDF        : numpy float32 array (vocab_size,)        — replaces Python dict
+  - doc_len    : numpy float32 array (n_docs,)            — replaces list[int]
+  - vocab      : plain dict[str, int]                     — word → column index
+
+Serialization uses numpy/scipy native binary formats instead of pickle:
+  tf_matrix.npz  — scipy sparse save_npz
+  arrays.npz     — numpy savez_compressed (idf, doc_len, scalar params)
+  vocab.json     — compact JSON (no whitespace)
+"""
+import json
+import logging
+from pathlib import Path
+
+import numpy as np
+from scipy.sparse import csr_matrix, load_npz, save_npz
+
+logger = logging.getLogger(__name__)
+
+_K1: float = 1.5
+_B: float = 0.75
+_DELTA: float = 1.0
+
+_TF_FILE = "tf_matrix.npz"
+_ARRAYS_FILE = "arrays.npz"
+_VOCAB_FILE = "vocab.json"
+
+
+class BM25PlusIndex:
+    """
+    Vectorized BM25Plus backed by a scipy CSR sparse TF matrix.
+
+    Scoring formula (per query term q, document d):
+        score(q, d) = IDF(q) * (tf(q,d)*(k1+1) / (tf(q,d) + k1*(1-b+b*|d|/avgdl)) + delta)
+    where IDF(q) = log((N+1) / df(q)).
+    """
+
+    def __init__(self, k1: float = _K1, b: float = _B, delta: float = _DELTA):
+        self.k1 = k1
+        self.b = b
+        self.delta = delta
+        self.vocab: dict[str, int] = {}
+        self.idf: np.ndarray | None = None
+        self.tf_matrix: csr_matrix | None = None
+        self.doc_len: np.ndarray | None = None
+        self.avgdl: float = 0.0
+        self.corpus_size: int = 0
+
+    def build(self, tokenized_corpus: list[list[str]]) -> None:
+        """Build index from a pre-tokenized corpus."""
+        n_docs = len(tokenized_corpus)
+        self.corpus_size = n_docs
+
+        # --- vocabulary ---
+        vocab: dict[str, int] = {}
+        for tokens in tokenized_corpus:
+            for t in tokens:
+                if t not in vocab:
+                    vocab[t] = len(vocab)
+        self.vocab = vocab
+        vocab_size = len(vocab)
+
+        # --- document lengths ---
+        doc_len = np.array([len(tokens) for tokens in tokenized_corpus], dtype=np.float32)
+        self.doc_len = doc_len
+        self.avgdl = float(doc_len.mean()) if n_docs > 0 else 1.0
+
+        # --- build sparse TF matrix (COO → CSR) ---
+        rows, cols, vals = [], [], []
+        nd = np.zeros(vocab_size, dtype=np.int32)  # document frequency per term
+
+        for doc_id, tokens in enumerate(tokenized_corpus):
+            freq: dict[int, int] = {}
+            for t in tokens:
+                wi = vocab[t]
+                freq[wi] = freq.get(wi, 0) + 1
+            for wi, tf in freq.items():
+                rows.append(doc_id)
+                cols.append(wi)
+                vals.append(float(tf))
+                nd[wi] += 1
+
+        self.tf_matrix = csr_matrix(
+            (vals, (rows, cols)), shape=(n_docs, vocab_size), dtype=np.float32
+        )
+
+        # --- IDF: log((N+1) / df) ---
+        self.idf = np.log((n_docs + 1.0) / nd.astype(np.float32)).astype(np.float32)
+
+    def get_scores(self, query_tokens: list[str]) -> np.ndarray:
+        """Return BM25Plus scores (float32) for all documents."""
+        if self.tf_matrix is None or not query_tokens:
+            return np.zeros(self.corpus_size, dtype=np.float32)
+
+        q_idx = [self.vocab[t] for t in query_tokens if t in self.vocab]
+        if not q_idx:
+            return np.zeros(self.corpus_size, dtype=np.float32)
+
+        # Dense slice for query terms only: (n_docs, n_q)
+        tf_sub = self.tf_matrix[:, q_idx].toarray()
+        dl_ratio = self.doc_len[:, np.newaxis] / self.avgdl  # (n_docs, 1)
+
+        numer = tf_sub * (self.k1 + 1.0)
+        denom = tf_sub + self.k1 * (1.0 - self.b + self.b * dl_ratio)
+        q_idf = self.idf[q_idx]  # (n_q,)
+
+        return (q_idf * (numer / denom + self.delta)).sum(axis=1)
+
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+
+    def save(self, cache_dir: Path) -> None:
+        """Serialize to cache_dir using scipy/numpy native formats."""
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+        save_npz(str(cache_dir / _TF_FILE), self.tf_matrix)
+
+        np.savez_compressed(
+            str(cache_dir / _ARRAYS_FILE),
+            idf=self.idf,
+            doc_len=self.doc_len,
+            params=np.array(
+                [self.k1, self.b, self.delta, self.avgdl, float(self.corpus_size)],
+                dtype=np.float64,
+            ),
+        )
+
+        with open(cache_dir / _VOCAB_FILE, "w", encoding="utf-8") as f:
+            json.dump(self.vocab, f, ensure_ascii=False, separators=(",", ":"))
+
+    @classmethod
+    def load(cls, cache_dir: Path) -> "BM25PlusIndex":
+        """Deserialize from cache_dir."""
+        obj = cls()
+        obj.tf_matrix = load_npz(str(cache_dir / _TF_FILE))
+
+        arr = np.load(str(cache_dir / _ARRAYS_FILE))
+        obj.idf = arr["idf"]
+        obj.doc_len = arr["doc_len"]
+        p = arr["params"]
+        obj.k1, obj.b, obj.delta, obj.avgdl = float(p[0]), float(p[1]), float(p[2]), float(p[3])
+        obj.corpus_size = int(p[4])
+
+        with open(cache_dir / _VOCAB_FILE, encoding="utf-8") as f:
+            obj.vocab = json.load(f)
+
+        return obj

--- a/src/vector_db/bm25_index.py
+++ b/src/vector_db/bm25_index.py
@@ -2,7 +2,7 @@
 Memory-efficient BM25Plus index using scipy sparse matrices.
 
 Replaces rank_bm25.BM25Plus:
-  - TF matrix  : scipy CSR sparse (n_docs × vocab_size)  — replaces list[dict] doc_freqs
+  - TF matrix  : scipy CSR sparse (n_docs * vocab_size)  — replaces list[dict] doc_freqs
   - IDF        : numpy float32 array (vocab_size,)        — replaces Python dict
   - doc_len    : numpy float32 array (n_docs,)            — replaces list[int]
   - vocab      : plain dict[str, int]                     — word → column index
@@ -12,6 +12,7 @@ Serialization uses numpy/scipy native binary formats instead of pickle:
   arrays.npz     — numpy savez_compressed (idf, doc_len, scalar params)
   vocab.json     — compact JSON (no whitespace)
 """
+
 import json
 import logging
 from pathlib import Path
@@ -84,9 +85,7 @@ class BM25PlusIndex:
                 vals.append(float(tf))
                 nd[wi] += 1
 
-        self.tf_matrix = csr_matrix(
-            (vals, (rows, cols)), shape=(n_docs, vocab_size), dtype=np.float32
-        )
+        self.tf_matrix = csr_matrix((vals, (rows, cols)), shape=(n_docs, vocab_size), dtype=np.float32)
 
         # --- IDF: log((N+1) / df) ---
         self.idf = np.log((n_docs + 1.0) / nd.astype(np.float32)).astype(np.float32)

--- a/src/vector_db/bm25_index.py
+++ b/src/vector_db/bm25_index.py
@@ -2,13 +2,17 @@
 Memory-efficient BM25Plus index using scipy sparse matrices.
 
 Replaces rank_bm25.BM25Plus:
-  - TF matrix  : scipy CSR sparse (n_docs * vocab_size)  — replaces list[dict] doc_freqs
+  - TF matrix  : scipy CSC sparse (n_docs × vocab_size)  — replaces list[dict] doc_freqs
   - IDF        : numpy float32 array (vocab_size,)        — replaces Python dict
   - doc_len    : numpy float32 array (n_docs,)            — replaces list[int]
   - vocab      : plain dict[str, int]                     — word → column index
 
+CSC (Compressed Sparse Column) is chosen over CSR because get_scores accesses
+the matrix column-by-column (one column per query token). CSC stores each column
+contiguously in indptr/indices/data, so a column slice is a zero-copy O(1) view.
+
 Serialization uses numpy/scipy native binary formats instead of pickle:
-  tf_matrix.npz  — scipy sparse save_npz
+  tf_matrix.npz  — scipy sparse save_npz (CSC preserved)
   arrays.npz     — numpy savez_compressed (idf, doc_len, scalar params)
   vocab.json     — compact JSON (no whitespace)
 """
@@ -18,7 +22,7 @@ import logging
 from pathlib import Path
 
 import numpy as np
-from scipy.sparse import csr_matrix, load_npz, save_npz
+from scipy.sparse import csc_matrix, load_npz, save_npz
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +37,7 @@ _VOCAB_FILE = "vocab.json"
 
 class BM25PlusIndex:
     """
-    Vectorized BM25Plus backed by a scipy CSR sparse TF matrix.
+    Vectorized BM25Plus backed by a scipy CSC sparse TF matrix.
 
     Scoring formula (per query term q, document d):
         score(q, d) = IDF(q) * (tf(q,d)*(k1+1) / (tf(q,d) + k1*(1-b+b*|d|/avgdl)) + delta)
@@ -46,7 +50,7 @@ class BM25PlusIndex:
         self.delta = delta
         self.vocab: dict[str, int] = {}
         self.idf: np.ndarray | None = None
-        self.tf_matrix: csr_matrix | None = None
+        self.tf_matrix: csc_matrix | None = None
         self.doc_len: np.ndarray | None = None
         self.avgdl: float = 0.0
         self.corpus_size: int = 0
@@ -70,7 +74,7 @@ class BM25PlusIndex:
         self.doc_len = doc_len
         self.avgdl = float(doc_len.mean()) if n_docs > 0 else 1.0
 
-        # --- build sparse TF matrix (COO → CSR) ---
+        # --- build sparse TF matrix (COO → CSC) ---
         rows, cols, vals = [], [], []
         nd = np.zeros(vocab_size, dtype=np.int32)  # document frequency per term
 
@@ -85,13 +89,18 @@ class BM25PlusIndex:
                 vals.append(float(tf))
                 nd[wi] += 1
 
-        self.tf_matrix = csr_matrix((vals, (rows, cols)), shape=(n_docs, vocab_size), dtype=np.float32)
+        self.tf_matrix = csc_matrix((vals, (rows, cols)), shape=(n_docs, vocab_size), dtype=np.float32)
 
         # --- IDF: log((N+1) / df) ---
         self.idf = np.log((n_docs + 1.0) / nd.astype(np.float32)).astype(np.float32)
 
     def get_scores(self, query_tokens: list[str]) -> np.ndarray:
-        """Return BM25Plus scores (float32) for all documents."""
+        """Return BM25Plus scores (float32) for all documents.
+
+        Uses CSC column slicing to process only non-zero (doc, term) pairs,
+        avoiding a full toarray() dense expansion that would spike to
+        O(n_docs × n_query_terms) memory regardless of corpus sparsity.
+        """
         if self.tf_matrix is None or not query_tokens:
             return np.zeros(self.corpus_size, dtype=np.float32)
 
@@ -99,15 +108,22 @@ class BM25PlusIndex:
         if not q_idx:
             return np.zeros(self.corpus_size, dtype=np.float32)
 
-        # Dense slice for query terms only: (n_docs, n_q)
-        tf_sub = self.tf_matrix[:, q_idx].toarray()
-        dl_ratio = self.doc_len[:, np.newaxis] / self.avgdl  # (n_docs, 1)
+        scores = np.zeros(self.corpus_size, dtype=np.float32)
+        # CSC indptr lets us slice column qi in O(1) with zero allocation:
+        #   indices[indptr[qi]:indptr[qi+1]] → doc ids that contain the term
+        #   data[indptr[qi]:indptr[qi+1]]    → their raw TF values
+        for qi in q_idx:
+            start, end = self.tf_matrix.indptr[qi], self.tf_matrix.indptr[qi + 1]
+            if start == end:
+                continue
+            doc_ids = self.tf_matrix.indices[start:end]
+            tf_vals = self.tf_matrix.data[start:end]
+            dl = self.doc_len[doc_ids]
+            numer = tf_vals * (self.k1 + 1.0)
+            denom = tf_vals + self.k1 * (1.0 - self.b + self.b * dl / self.avgdl)
+            scores[doc_ids] += self.idf[qi] * (numer / denom + self.delta)
 
-        numer = tf_sub * (self.k1 + 1.0)
-        denom = tf_sub + self.k1 * (1.0 - self.b + self.b * dl_ratio)
-        q_idf = self.idf[q_idx]  # (n_q,)
-
-        return (q_idf * (numer / denom + self.delta)).sum(axis=1)
+        return scores
 
     # ------------------------------------------------------------------
     # Serialization

--- a/src/vector_db/bm25_manager.py
+++ b/src/vector_db/bm25_manager.py
@@ -1,54 +1,45 @@
 import json
 import logging
-import pickle
 from typing import Any
 
 from kiwipiepy import Kiwi
-from rank_bm25 import BM25Plus
 
-from src.common.constants import DataFields
-from src.utils.paths import BM25_CACHE_FILE, PROCESSED_DATA_DIR, SYNONYMS_FILE
+from src.common.constants import DataFields, MetadataFields
+from src.utils.paths import BM25_CACHE_DIR, PROCESSED_DATA_DIR, SYNONYMS_FILE
+from src.vector_db.bm25_index import BM25PlusIndex
 
 logger = logging.getLogger(__name__)
+
+_CORPUS_FILE = "corpus.json"
+_MANIFEST_FILE = "manifest.json"
 
 
 class BM25Manager:
     """
     키워드 기반 검색(BM25)을 관리하는 클래스.
     가공된 JSON 데이터를 로드하여 인덱스를 빌드하고, 형태소 분석 기반의 키워드 검색을 수행함.
+
+    인덱스 캐시 구조 (.cache/bm25_v2/):
+      tf_matrix.npz  — scipy sparse CSR TF 행렬
+      arrays.npz     — numpy: idf 배열, doc_len 배열, 스칼라 파라미터
+      vocab.json     — 단어→열 인덱스 매핑
+      corpus.json    — 슬림 코퍼스 (content + metadata + chunk_id만 보존)
+      manifest.json  — 캐시 유효성 타임스탬프
     """
 
-    def __init__(self, data_dir=PROCESSED_DATA_DIR):
-        """
-        BM25 매니저 초기화.
-
-        Args:
-            data_dir (Path): 가공된 JSON 파일들이 위치한 디렉토리 경로.
-        """
+    def __init__(self, data_dir=PROCESSED_DATA_DIR, cache_dir=BM25_CACHE_DIR):
         self.data_dir = data_dir
+        self.cache_dir = cache_dir
         self.kiwi = Kiwi()
-        self.bm25 = None
-        self.corpus_data = []
-
-        # 중앙 관리되는 캐시 파일 경로 사용
-        self.cache_path = BM25_CACHE_FILE
-
-        # 동의어 사전 로드
+        self.bm25: BM25PlusIndex | None = None
+        self.corpus_data: list[dict] = []
         self.synonyms = self._load_synonyms()
-
         self.load_index()
 
     def _load_synonyms(self) -> dict:
-        """
-        외부 JSON 파일에서 동의어 사전을 로드함.
-
-        Returns:
-            dict: {줄임말: 정식명칭} 구조의 동의어 딕셔너리.
-        """
         if not SYNONYMS_FILE.exists():
             logger.warning(f"동의어 파일을 찾을 수 없습니다: {SYNONYMS_FILE} (빈 사전 사용)")
             return {}
-
         try:
             with open(SYNONYMS_FILE, encoding="utf-8") as f:
                 return json.load(f)
@@ -57,15 +48,6 @@ class BM25Manager:
             return {}
 
     def _apply_synonyms(self, text: str) -> str:
-        """
-        입력 텍스트의 줄임말 등을 정식 명칭으로 치환함.
-
-        Args:
-            text (str): 치환 전 원본 텍스트.
-
-        Returns:
-            str: 동의어가 치환된 텍스트.
-        """
         if not self.synonyms:
             return text
         for k, v in self.synonyms.items():
@@ -73,59 +55,34 @@ class BM25Manager:
         return text
 
     def _tokenizer(self, text: str) -> list[str]:
-        """
-        한국어 형태소 분석을 통해 의미 있는 토큰(명사, 용언 등)만 추출함.
-
-        Args:
-            text (str): 분석할 원본 텍스트.
-
-        Returns:
-            list[str]: 정제된 토큰 리스트.
-        """
+        """한국어 형태소 분석을 통해 의미 있는 토큰(명사, 용언 등)만 추출함."""
         if not text:
             return []
         text = self._apply_synonyms(text)
-
         # N: 명사, V: 용언(동사/형용사), S: 외국어/숫자 추출 및 1글자 노이즈 제거
-        tokens = [t.form for t in self.kiwi.tokenize(text) if t.tag.startswith(("N", "V", "S")) and len(t.form) > 1]
-        return tokens
+        return [
+            t.form
+            for t in self.kiwi.tokenize(text)
+            if t.tag.startswith(("N", "V", "S")) and len(t.form) > 1
+        ]
 
     def _get_all_json_files(self) -> list:
-        """
-        데이터 디렉토리 내의 모든 JSON 파일 리스트를 반환함.
-
-        Returns:
-            list[Path]: JSON 파일 경로 리스트.
-        """
         return list(self.data_dir.glob("*.json"))
 
     def _should_rebuild_index(self, json_files: list) -> bool:
-        """
-        캐시 파일의 유효성을 검사하여 인덱스 재빌드 여부를 결정함.
-
-        Args:
-            json_files (list): 현재 디렉토리에 존재하는 소스 JSON 파일 리스트.
-
-        Returns:
-            bool: 재빌드가 필요하면 True, 아니면 False.
-        """
-        if not self.cache_path.exists():
+        """manifest.json 타임스탬프를 기준으로 재빌드 여부를 결정함."""
+        manifest_path = self.cache_dir / _MANIFEST_FILE
+        if not manifest_path.exists():
             return True
-
-        # 소스 파일 중 하나라도 캐시보다 최신이면 재빌드 필요
         last_mtime = max((f.stat().st_mtime for f in json_files), default=0)
-        return last_mtime > self.cache_path.stat().st_mtime
+        return last_mtime > manifest_path.stat().st_mtime
 
     def _flatten_data(self, data: Any) -> list[dict]:
         """
-        계층형 구조(children 리스트 포함)의 데이터를 평탄화하여 리스트로 반환함.
-        'text', 'content', 'parent_text' 필드를 데이터의 본문으로 간주함.
-
-        Args:
-            data (Any): JSON에서 로드된 원본 데이터 (dict 또는 list).
-
-        Returns:
-            list[dict]: 평탄화된 문서 조각 리스트.
+        계층형 구조를 평탄화하며, 검색에 필요한 필드만 보존함.
+          - content  : 검색 본문 (text / content / parent_text 우선순위)
+          - metadata : 출처 메타데이터
+          - chunk_id : RRF 중복 제거용 (최상위 필드에 존재할 경우만)
         """
         flattened = []
 
@@ -135,16 +92,22 @@ class BM25Manager:
             return flattened
 
         if isinstance(data, dict):
-            # 본문 필드 추출 (text 우선, 없으면 content, 그 다음 parent_text)
-            text_content = data.get(DataFields.TEXT) or data.get(DataFields.CONTENT) or data.get(DataFields.PARENT_TEXT)
+            text_content = (
+                data.get(DataFields.TEXT)
+                or data.get(DataFields.CONTENT)
+                or data.get(DataFields.PARENT_TEXT)
+            )
 
-            # 본문이 있는 경우 현재 노드 추가
             if text_content:
-                # content 필드로 통일하여 저장 (기존 코드 호환성)
-                node = {**data, DataFields.CONTENT: text_content}
+                node: dict = {
+                    DataFields.CONTENT: text_content,
+                    DataFields.METADATA: data.get(DataFields.METADATA) or {},
+                }
+                # chunk_id가 최상위에 존재하면 보존 (RRF 중복 제거용)
+                if MetadataFields.CHUNK_ID in data:
+                    node[MetadataFields.CHUNK_ID] = data[MetadataFields.CHUNK_ID]
                 flattened.append(node)
 
-            # 자식 노드가 있는 경우 재귀적으로 탐색
             children = data.get(DataFields.CHILDREN)
             if children and isinstance(children, list):
                 for child in children:
@@ -155,7 +118,7 @@ class BM25Manager:
     def load_index(self):
         """
         가공된 데이터를 로드하여 BM25 인덱스를 빌드함.
-        캐시가 유효하면 캐시를 로드하고, 그렇지 않으면 신규 빌드함.
+        캐시가 유효하면 numpy/scipy 포맷으로 캐시를 로드하고, 그렇지 않으면 신규 빌드함.
         """
         json_files = self._get_all_json_files()
 
@@ -166,12 +129,10 @@ class BM25Manager:
             return
 
         try:
-            # 캐시 로드 시도
             if not self._should_rebuild_index(json_files):
-                with open(self.cache_path, "rb") as f:
-                    cached_data = pickle.load(f)
-                    self.bm25 = cached_data["bm25"]
-                    self.corpus_data = cached_data["corpus_data"]
+                self.bm25 = BM25PlusIndex.load(self.cache_dir)
+                with open(self.cache_dir / _CORPUS_FILE, encoding="utf-8") as f:
+                    self.corpus_data = json.load(f)
                 logger.info(f"통합 인덱스 로드 완료 (Cache): {len(self.corpus_data)} docs")
                 return
 
@@ -181,22 +142,20 @@ class BM25Manager:
             for json_file in json_files:
                 with open(json_file, encoding="utf-8") as f:
                     try:
-                        data = json.load(f)
-                        all_raw_data.append(data)
+                        all_raw_data.append(json.load(f))
                     except json.JSONDecodeError as e:
                         logger.error(f"JSON 파싱 오류 ({json_file.name}): {e}")
 
-            # 데이터 평탄화 및 정제
             self.corpus_data = self._flatten_data(all_raw_data)
 
             if not self.corpus_data:
                 logger.warning("유효한 텍스트 데이터가 없어 인덱스를 생성할 수 없습니다.")
                 return
 
-            # 모든 문서를 토큰화하여 BM25 인덱스 생성
-            tokenized_corpus = [self._tokenizer(doc.get(DataFields.CONTENT, "")) for doc in self.corpus_data]
+            tokenized_corpus = [
+                self._tokenizer(doc.get(DataFields.CONTENT, "")) for doc in self.corpus_data
+            ]
 
-            # 유효한 토큰이 있는 문서만 인덱싱 (BM25Plus 에러 방지)
             valid_indices = [i for i, tokens in enumerate(tokenized_corpus) if tokens]
             if not valid_indices:
                 logger.warning("토큰화된 유효 데이터가 없습니다.")
@@ -205,12 +164,17 @@ class BM25Manager:
             self.corpus_data = [self.corpus_data[i] for i in valid_indices]
             tokenized_corpus = [tokenized_corpus[i] for i in valid_indices]
 
-            self.bm25 = BM25Plus(tokenized_corpus)
+            self.bm25 = BM25PlusIndex()
+            self.bm25.build(tokenized_corpus)
 
-            # 빌드된 인덱스 캐싱
-            self.cache_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(self.cache_path, "wb") as f:
-                pickle.dump({"bm25": self.bm25, "corpus_data": self.corpus_data}, f)
+            # 직렬화 저장 (numpy/scipy 네이티브 포맷)
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+            self.bm25.save(self.cache_dir)
+            with open(self.cache_dir / _CORPUS_FILE, "w", encoding="utf-8") as f:
+                json.dump(self.corpus_data, f, ensure_ascii=False, separators=(",", ":"))
+            with open(self.cache_dir / _MANIFEST_FILE, "w", encoding="utf-8") as f:
+                json.dump({"docs": len(self.corpus_data)}, f)
+
             logger.info(f"통합 인덱스 빌드 및 저장 완료: {len(self.corpus_data)} docs")
 
         except Exception as e:
@@ -240,14 +204,12 @@ class BM25Manager:
         if not tokenized_query:
             return []
 
-        # BM25 점수 계산
         scores = self.bm25.get_scores(tokenized_query)
-        if not any(scores):
+        if not scores.any():
             return []
 
-        # 상위 N개 인덱스 추출
         top_indices = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[:n]
-        top_scores = [scores[i] for i in top_indices]
+        top_scores = [float(scores[i]) for i in top_indices]
 
         # 타 검색 엔진과의 결합을 위한 점수 정규화 (Min-Max Scaling)
         s_max, s_min = max(top_scores), min(top_scores)
@@ -258,7 +220,6 @@ class BM25Manager:
         for rank, (idx, norm_score) in enumerate(zip(top_indices, normalized, strict=False)):
             doc = self.corpus_data[idx]
             if return_scores:
-                # 하이브리드 검색을 위한 메타데이터 추가
                 results.append({**doc, "_bm25_score": round(norm_score, 4), "_rank": rank + 1})
             else:
                 results.append(doc)

--- a/src/vector_db/bm25_manager.py
+++ b/src/vector_db/bm25_manager.py
@@ -60,11 +60,7 @@ class BM25Manager:
             return []
         text = self._apply_synonyms(text)
         # N: 명사, V: 용언(동사/형용사), S: 외국어/숫자 추출 및 1글자 노이즈 제거
-        return [
-            t.form
-            for t in self.kiwi.tokenize(text)
-            if t.tag.startswith(("N", "V", "S")) and len(t.form) > 1
-        ]
+        return [t.form for t in self.kiwi.tokenize(text) if t.tag.startswith(("N", "V", "S")) and len(t.form) > 1]
 
     def _get_all_json_files(self) -> list:
         return list(self.data_dir.glob("*.json"))
@@ -92,11 +88,7 @@ class BM25Manager:
             return flattened
 
         if isinstance(data, dict):
-            text_content = (
-                data.get(DataFields.TEXT)
-                or data.get(DataFields.CONTENT)
-                or data.get(DataFields.PARENT_TEXT)
-            )
+            text_content = data.get(DataFields.TEXT) or data.get(DataFields.CONTENT) or data.get(DataFields.PARENT_TEXT)
 
             if text_content:
                 node: dict = {
@@ -152,9 +144,7 @@ class BM25Manager:
                 logger.warning("유효한 텍스트 데이터가 없어 인덱스를 생성할 수 없습니다.")
                 return
 
-            tokenized_corpus = [
-                self._tokenizer(doc.get(DataFields.CONTENT, "")) for doc in self.corpus_data
-            ]
+            tokenized_corpus = [self._tokenizer(doc.get(DataFields.CONTENT, "")) for doc in self.corpus_data]
 
             valid_indices = [i for i, tokens in enumerate(tokenized_corpus) if tokens]
             if not valid_indices:

--- a/src/vector_db/bm25_manager.py
+++ b/src/vector_db/bm25_manager.py
@@ -1,7 +1,9 @@
 import json
 import logging
+import traceback
 from typing import Any
 
+import numpy as np
 from kiwipiepy import Kiwi
 
 from src.common.constants import DataFields, MetadataFields
@@ -20,7 +22,7 @@ class BM25Manager:
     가공된 JSON 데이터를 로드하여 인덱스를 빌드하고, 형태소 분석 기반의 키워드 검색을 수행함.
 
     인덱스 캐시 구조 (.cache/bm25_v2/):
-      tf_matrix.npz  — scipy sparse CSR TF 행렬
+      tf_matrix.npz  — scipy sparse CSC TF 행렬
       arrays.npz     — numpy: idf 배열, doc_len 배열, 스칼라 파라미터
       vocab.json     — 단어→열 인덱스 매핑
       corpus.json    — 슬림 코퍼스 (content + metadata + chunk_id만 보존)
@@ -169,8 +171,6 @@ class BM25Manager:
 
         except Exception as e:
             logger.error(f"인덱스 로드 중 오류 발생: {e}")
-            import traceback
-
             logger.error(traceback.format_exc())
             self.bm25 = None
             self.corpus_data = []
@@ -198,7 +198,12 @@ class BM25Manager:
         if not scores.any():
             return []
 
-        top_indices = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)[:n]
+        n_docs = len(scores)
+        if n_docs <= n:
+            top_indices = np.argsort(scores)[::-1].tolist()
+        else:
+            top_k = np.argpartition(scores, -n)[-n:]
+            top_indices = top_k[np.argsort(scores[top_k])[::-1]].tolist()
         top_scores = [float(scores[i]) for i in top_indices]
 
         # 타 검색 엔진과의 결합을 위한 점수 정규화 (Min-Max Scaling)


### PR DESCRIPTION
## 변경 사항 (Checklist)

* [ ] 새로운 기능 추가 (feature)
* [ ] 버그 수정 (fix)
* [x] 리팩토링 (refactor)
* [ ] 문서 수정 (docs)
* [ ] 환경 설정 (setup)

## 주요 작업 내용

- **`src/vector_db/bm25_index.py` (신규)**: `rank_bm25.BM25Plus`를 대체하는 `BM25PlusIndex` 클래스 구현
  - `doc_freqs: list[dict]` → `scipy CSC sparse matrix` (n_docs × vocab_size)
  - `idf: dict[str, float]` → `numpy float32 ndarray` (vocab_size,)
  - `doc_len: list[int]` → `numpy float32 ndarray` (n_docs,)
  - `save()` / `load()`: `pickle` 대신 `scipy.sparse.save_npz` + `numpy.savez_compressed` + compact JSON
- **`src/vector_db/bm25_manager.py` (수정)**:
  - `rank_bm25` / `pickle` 의존성 완전 제거
  - `_flatten_data`: `{**data}` 전체 복사 → `content + metadata + chunk_id`만 보존으로 corpus 슬림화
  - 캐시 경로: `bm25_index.pkl` (단일 파일) → `bm25_v2/` (디렉토리, manifest 기반 invalidation)
  - `cache_dir` 파라미터 추가로 테스트 격리 지원
- **`src/utils/paths.py` (수정)**: `BM25_CACHE_DIR = CACHE_DIR / "bm25_v2"` 추가
- **`src/tests/integration/test_bm25.py` (수정)**: 9개 테스트 — corpus 슬림화 검증, 직렬화 라운드트립, `cache_dir` 격리 추가

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**: 모니터링 시스템 도입 후 BM25 검색 단계에서 메모리 점유율 및 직렬화 오버헤드가 측정됨. `rank_bm25.BM25Plus`는 역색인을 `list[dict]` 구조로 관리하여 Python 객체 오버헤드가 컸으며, `pickle`을 통한 전체 인스턴스 직렬화는 파일 크기와 로드 시간에 불리함.

* **원인 분석**:
  1. `doc_freqs: list[dict]` — N 문서 × M 고유어의 Python `dict`는 해시테이블 메타데이터만으로도 항목당 200~400 bytes 오버헤드 발생
  2. `idf: dict[str, float]` — 어휘 크기만큼의 Python 객체 오버헤드
  3. `corpus_data`에 `{**data}` 전체 복사 — `text`, `parent_text`, `children` 등 검색에 불필요한 모든 필드 메모리 적재
  4. `pickle`: Python 버전 종속, 검증 없는 역직렬화, 큰 바이너리 블롭

* **해결 방안 및 의사결정**:
  - 역색인 데이터 구조를 **`scipy CSC sparse matrix`** 로 교체. CSC(Compressed Sparse Column) 포맷은 `get_scores`의 열(쿼리 토큰) 단위 접근 패턴에 최적화되어, `indptr`를 통해 각 열(단어)의 비-zero 문서 목록을 O(1) 뷰로 취득 가능.
  - `get_scores`에서 기존 `toarray()`에 의한 Dense 변환 없이, CSC `indptr/indices/data` 배열을 직접 슬라이싱하여 해당 단어가 등장한 문서만 처리:
    ```python
    for qi in q_idx:
        start, end = tf_matrix.indptr[qi], tf_matrix.indptr[qi + 1]
        doc_ids = tf_matrix.indices[start:end]   # zero-copy view
        tf_vals = tf_matrix.data[start:end]       # zero-copy view
        scores[doc_ids] += idf[qi] * (numer / denom + delta)
    ```
  - IDF / doc_len은 `numpy float32 ndarray`로 통일하여 연속 메모리 배열로 전환.
  - 직렬화를 `scipy.sparse.save_npz` + `numpy.savez_compressed`로 교체. numpy/scipy 네이티브 포맷은 pickle 대비 파일이 작고 mmap 지연 로딩이 가능.
  - `corpus_data`에서 검색 결과 반환에 불필요한 필드(`text`, `parent_text`, `children` 등)를 `_flatten_data` 단계에서 제거.

## 테스트 결과 / 결과 증빙 (Screenshots / Logs)

**테스트 결과 (9/9 PASSED)**
```
src/tests/integration/test_bm25.py::test_multi_file_loading       PASSED
src/tests/integration/test_bm25.py::test_search_basic             PASSED
src/tests/integration/test_bm25.py::test_synonyms_from_file       PASSED
src/tests/integration/test_bm25.py::test_no_result                PASSED
src/tests/integration/test_bm25.py::test_hierarchical_loading     PASSED
src/tests/integration/test_bm25.py::test_corpus_fields_slim       PASSED  ← 신규
src/tests/integration/test_bm25.py::test_cache_roundtrip          PASSED  ← 신규
src/tests/integration/test_bm25.py::test_bm25_index_serialization PASSED  ← 신규
src/tests/integration/test_bm25.py::test_return_scores_flag       PASSED  ← 신규
9 passed in 36.20s
```

**캐시 구조 변경 (Before → After)**
```
# Before
.cache/
  bm25_index.pkl          ← Python pickle (단일 블롭, 버전 종속)

# After
.cache/bm25_v2/
  tf_matrix.npz           ← scipy sparse CSC (TF 행렬)
  arrays.npz              ← numpy compressed (idf, doc_len, params)
  vocab.json              ← compact JSON, 공백 없음
  corpus.json             ← 슬림 코퍼스 (content + metadata + chunk_id)
  manifest.json           ← 캐시 유효성 타임스탬프
```

**데이터 구조 변경 (Before → After)**
```
# Before — Python 객체 오버헤드 큼
bm25.doc_freqs = [{"휴학": 2, "신청": 1, ...}, ...]   # list[dict], N × M entries
bm25.idf       = {"휴학": 2.34, "신청": 1.87, ...}    # dict[str, float]

# After — 연속 메모리, 오버헤드 없음
bm25.tf_matrix : scipy CSC (1119 docs × 1864 terms, nnz=26005, sparsity=98.75%)
bm25.idf       : numpy ndarray (1864,), float32
bm25.doc_len   : numpy ndarray (1119,), float32
```

---

## DoD 증빙 지표 (실측 데이터, 1,119 docs / vocab 1,864 terms)

> 측정 환경: Windows 11, Python 3.13.9, 동일 코퍼스 (processed/*.json), n=50~100회 반복 평균

### 1. 인덱스 파일 크기

| 항목 | Before (pickle) | After (scipy/numpy) | 변화 |
|------|----------------|---------------------|------|
| bm25 인덱스 전체 | **1,291.9 KB** (pkl 단일 파일) | **59.2 KB** (tf_matrix.npz 30.2 + arrays.npz 3.8 + vocab.json 25.2) | **-95.4%** |
| corpus 저장 | pickle 내 포함 (불분리) | 1,005.3 KB (corpus.json, 슬림화) | 분리·슬림화 |
| 합계 | 1,291.9 KB | 1,064.4 KB | **-17.6%** |

> **핵심**: BM25 인덱스 자체(tf_matrix + arrays + vocab)는 59.2 KB로 약 95% 감소. corpus.json은 별도 파일로 분리되어 필요 시 mmap 지연 로드가 가능해짐.

### 2. RAM 점유량 (tracemalloc 기준 peak)

| 측정 항목 | Before | After | 감소율 |
|-----------|--------|-------|--------|
| pickle.load (인덱스+코퍼스) | **12,940 KB** (~12.6 MB) | — | — |
| BM25PlusIndex.load만 (인덱스 단독) | — | **544 KB** (0.5 MB) | — |
| BM25Manager 전체 로드 (인덱스+코퍼스) | ~12,940 KB | **7,486 KB** (~7.3 MB) | **-42%** |

> pickle은 역직렬화 시 Python 객체 그래프 전체를 메모리에 재구성하므로 피크가 높음. scipy/numpy 네이티브 포맷은 필요한 배열만 적재하여 절반 수준으로 감소.

### 3. 쿼리 레이턴시 (get_scores, n=50~100회)

| 쿼리 예시 | Before (rank_bm25) | After (CSC sparse) | 개선율 |
|-----------|-------------------|-------------------|--------|
| ['휴학', '신청', '방법'] | avg **0.22 ms**, p50 0.20 ms | avg **0.024 ms**, p50 0.023 ms | **~9× 단축** |
| ['장학금', '지원', '대상'] | avg ~0.22 ms | avg **0.022 ms** | **~10× 단축** |
| ['수강', '신청', '변경'] | avg ~0.22 ms | avg **0.024 ms** | **~9× 단축** |

> CSC `indptr` 직접 슬라이싱으로 비-zero 문서만 처리(nnz=26,005 / 전체 2,087,716 셀, sparsity 98.75%). `toarray()` Dense 변환 없이 numpy 배열 산술만 수행하므로 레이턴시가 대폭 단축됨.

---

## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요?
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
* [x] 관련 이슈 번호를 연결했나요? (Resolves #109)
* [x] 주간 발표 자료로 활용 가능한 직관적인 결과물(스크린샷/로그)을 첨부했나요?
* [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디

`rank_bm25` 라이브러리 의존성을 완전히 제거하고 scipy/numpy 스택으로 전환했습니다. 공개 인터페이스(`BM25Manager.get_top_n`, `load_index`)는 동일하게 유지되어 `EnsembleRetriever` 등 호출부 수정이 없습니다.

**추가 개선 (리뷰 피드백 반영)**: `get_scores` 내 `toarray()` Dense 변환을 완전 제거하고 CSC `indptr` 직접 슬라이싱으로 교체했습니다. 이로써 n_docs가 수만 건 이상으로 확장될 때에도 쿼리 1회당 메모리 할당이 O(nnz_per_term)으로 유지됩니다 (이전: O(n_docs × n_query_terms)).

기존 `.cache/bm25_index.pkl`은 더 이상 참조되지 않으며, 첫 실행 시 `.cache/bm25_v2/`로 자동 재빌드됩니다.

Resolves #109