### PR TITLE
feat: 동기화 파서 선택 및 파일별 청크 데이터 시각화 뷰어 구현 (#111)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -438,20 +438,16 @@ def show_admin_dialog(db_manager):  # noqa: C901
             "<hr style='margin: 0px 0px 10px 0px; border: 0.5px solid rgba(151,166,195,0.2);'>",
             unsafe_allow_html=True,
         )
-
-        # ChromaDB에서 실제 메타데이터를 가져와 파서 타입 확인 (캐싱된 헬퍼 사용)
-        file_parser_map = _get_file_parser_map(db_manager)
-
         for i, f in enumerate(current_files):
             r_col1, r_col2, r_col3, r_col4, r_col5, r_col6, r_col7, r_col8 = st.columns(
                 [0.3, 2.0, 0.6, 0.9, 0.9, 0.6, 0.6, 0.6]
             )
             r_col1.write(f"{i + 1}")
-            
+
             # 적용 파서 식별 (매니페스트 우선 조회, 차선으로 ChromaDB 조회)
             import unicodedata
             rel_path = unicodedata.normalize("NFC", str(f.relative_to(RAW_DATA_DIR)))
-            
+
             r_col2.text(rel_path)  # 파일명 대신 상대 경로 표시
             r_col3.write(format_size(f.stat().st_size))
 
@@ -548,33 +544,7 @@ def show_admin_dialog(db_manager):  # noqa: C901
                 st.rerun()
 
             if r_col8.button("🗑️", key=f"del_btn_{i}", help=f"'{f.name}' 삭제") and f.exists():
-=======
-            # 파서 타입 표시
-            parser_type = file_parser_map.get(rel_path, "-")
-            parser_color = "blue" if parser_type == "docling" else "green" if parser_type == "manual" else "gray"
-            r_col4.markdown(f":{parser_color}[{parser_type}]")
 
-            # 청크 수 조회 시에도 상대 경로 또는 파일명 사용 (Legacy 대응)
-            chunk_count = db_manager.get_source_count(f.name)
-            if chunk_count == 0 and rel_path != f.name:
-                # relative_path로 다시 시도
-                # (db_manager.get_source_count가 MetadataFields.SRC_NAME만 볼 경우 대응 필요)
-                pass
-            r_col5.write(f"{chunk_count}")
-
-            # 개별 동기화 버튼
-            if r_col6.button("🔄", key=f"sync_btn_{i}", help=f"'{f.name}' 개별 동기화"):
-                orchestrator = PipelineOrchestrator()
-                with st.spinner(f"{f.name} 동기화 중..."):
-                    if orchestrator.process_single_file(f):
-                        st.toast(f"동기화 완료: {f.name}")
-                        initialize_rag_system.clear()
-                        time.sleep(0.5)
-                        st.rerun()
-
-            # 삭제 버튼
-            if r_col7.button("🗑️", key=f"del_btn_{i}", help=f"'{f.name}' 삭제") and f.exists():
->>>>>>> origin/develop
                 f.unlink()
                 st.toast(f"파일 삭제됨: {f.name}")
                 if auto_sync:

--- a/src/app.py
+++ b/src/app.py
@@ -64,6 +64,8 @@ if "dialog_doc_to_show" not in st.session_state:
     st.session_state.dialog_doc_to_show = None
 if "dialog_chunks_file_to_show" not in st.session_state:
     st.session_state.dialog_chunks_file_to_show = None
+if "parser_change_pending" not in st.session_state:
+    st.session_state.parser_change_pending = None
 if "is_generating" not in st.session_state:
     st.session_state.is_generating = False
 if "should_rerun_app" not in st.session_state:
@@ -172,15 +174,17 @@ def show_admin_dialog(db_manager):  # noqa: C901
     def trigger_sync(force=False):
         progress_bar = st.progress(0)
 
-        def sync_callback(current, total, file_name):
-            if total > 0:
-                percent = int((current / total) * 100)
-                percent = min(100, max(0, percent))
-                progress_bar.progress(percent, text=f"[{current}/{total}] {file_name} 처리 중... ({percent}%)")
-            else:
-                progress_bar.progress(0, text="대기 중...")
-
         with st.status("데이터베이스 동기화 중...", expanded=True) as status:
+            def sync_callback(current, total, file_name, pb=progress_bar, st_status=status):
+                if total > 0:
+                    percent = int((current / total) * 100)
+                    percent = min(100, max(0, percent))
+                    pb.progress(percent, text=f"[{current}/{total}] {file_name} 처리 중... ({percent}%)")
+                    st_status.update(label=f"진행 중: {file_name}", state="running")
+                    st.write(f"[{current}/{total}] {file_name} 처리 완료 ({percent}%)")
+                else:
+                    pb.progress(0, text="대기 중...")
+
             # 싱글톤 인스턴스 사용 (불필요한 모델 로드 방지)
             orchestrator = PipelineOrchestrator()
             orchestrator.run_ingestion(force=force, parser_type=parser_type, progress_callback=sync_callback)
@@ -249,39 +253,128 @@ def show_admin_dialog(db_manager):  # noqa: C901
     if not current_files:
         st.info("현재 등록된 문서가 없습니다.")
     else:
-        h_col1, h_col2, h_col3, h_col4, h_col5, h_col6 = st.columns([0.2, 2.5, 0.8, 0.8, 0.6, 0.6])
+        orchestrator = PipelineOrchestrator()
+        manifest = orchestrator._load_manifest()
+        manifest_files = manifest.get("files", {})
+
+        h_col1, h_col2, h_col3, h_col4, h_col5, h_col6, h_col7, h_col8 = st.columns(
+            [0.3, 2.0, 0.6, 0.9, 0.9, 0.6, 0.6, 0.6]
+        )
         h_col1.write("**No**")
         h_col2.write("**파일명**")
         h_col3.write("**크기**")
-        h_col4.write("**적용 파서**")
-        h_col5.write("**청크**")
-        h_col6.write("**삭제**")
+        h_col4.write("**상태**")
+        h_col5.write("**적용 파서**")
+        h_col6.write("**청크**")
+        h_col7.write("**동기화**")
+        h_col8.write("**삭제**")
         st.markdown(
             "<hr style='margin: 0px 0px 10px 0px; border: 0.5px solid rgba(151,166,195,0.2);'>",
             unsafe_allow_html=True,
         )
 
         for i, f in enumerate(current_files):
-            r_col1, r_col2, r_col3, r_col4, r_col5, r_col6 = st.columns([0.2, 2.5, 0.8, 0.8, 0.6, 0.6])
+            r_col1, r_col2, r_col3, r_col4, r_col5, r_col6, r_col7, r_col8 = st.columns(
+                [0.3, 2.0, 0.6, 0.9, 0.9, 0.6, 0.6, 0.6]
+            )
             r_col1.write(f"{i + 1}")
             r_col2.text(f.name)
             r_col3.write(format_size(f.stat().st_size))
 
-            # 적용 파서 식별
+            # 적용 파서 식별 (매니페스트 우선 조회, 차선으로 ChromaDB 조회)
+            rel_path = str(f.relative_to(RAW_DATA_DIR))
+            file_manifest_info = manifest_files.get(rel_path, {})
+            parser_name = file_manifest_info.get("parser_type")
+
             chunks = db_manager.get_source_chunks(f.name)
-            parser_name = "-"
-            if chunks:
-                parser_name = chunks[0].get("metadata", {}).get("parser", "manual")
-            r_col4.write(f"`{parser_name}`")
+            chunk_count = len(chunks)
+            if not parser_name:
+                parser_name = parser_type
+                if chunks:
+                    parser_name = chunks[0].get("metadata", {}).get("parser", parser_type)
+
+            parser_options = ["manual", "docling"]
+
+            # 청크 개수가 0개이면 미동기화, 0보다 크면 동기화 완료 배지 표시
+            pending = st.session_state.get("parser_change_pending") or {}
+            if chunk_count == 0:
+                r_col4.markdown(
+                    "<div style='color: #ff4b4b; font-size: 0.8rem; "
+                    "font-weight: bold; white-space: nowrap; margin-top: 6px;'>미동기화 (대기)</div>",
+                    unsafe_allow_html=True,
+                )
+                display_parser = pending.get(f.name, parser_name or parser_type)
+            else:
+                r_col4.markdown(
+                    "<div style='color: #00cc66; font-size: 0.8rem; "
+                    "font-weight: bold; white-space: nowrap; margin-top: 6px;'>동기화 완료</div>",
+                    unsafe_allow_html=True,
+                )
+                display_parser = pending.get(f.name, parser_name)
+
+            try:
+                selected_idx = parser_options.index(display_parser.lower())
+            except ValueError:
+                selected_idx = 0
+
+            selected_parser = r_col5.selectbox(
+                "파서 선택",
+                options=parser_options,
+                index=selected_idx,
+                key=f"parser_select_{i}_{display_parser}",
+                label_visibility="collapsed",
+                disabled=False,
+            )
+
+            if selected_parser != parser_name:
+                if f.name not in pending or pending[f.name] != selected_parser:
+                    if st.session_state.parser_change_pending is None:
+                        st.session_state.parser_change_pending = {}
+                    st.session_state.parser_change_pending[f.name] = selected_parser
+                    st.rerun()
+            elif f.name in pending:
+                st.session_state.parser_change_pending.pop(f.name, None)
+                if not st.session_state.parser_change_pending:
+                    st.session_state.parser_change_pending = None
+                st.rerun()
 
             chunk_count = len(chunks)
-            if r_col5.button(f"{chunk_count} 🔍", key=f"view_chunks_{i}", help="청크 상세 내용 보기"):
+            if r_col6.button(f"{chunk_count} 🔍", key=f"view_chunks_{i}", help="청크 상세 내용 보기"):
                 st.session_state.dialog_chunks_file_to_show = f.name
                 st.session_state.admin_active = False
                 st.session_state.should_rerun_app = True
                 st.rerun()
 
-            if r_col6.button("🗑️", key=f"del_btn_{i}", help=f"'{f.name}' 삭제") and f.exists():
+            # 개별 동기화/재색인 실행
+            if r_col7.button("🔄", key=f"sync_btn_{i}", help="개별 동기화 및 재색인 실행"):
+                active_parser = selected_parser
+                if pending and f.name in pending:
+                    st.session_state.parser_change_pending.pop(f.name, None)
+                    if not st.session_state.parser_change_pending:
+                        st.session_state.parser_change_pending = None
+
+                progress_bar = st.progress(0)
+                with st.status(f"{f.name} 개별 동기화 중...", expanded=True) as status:
+                    def single_file_sync_callback(current, total, name, pb=progress_bar, st_status=status):
+                        if total > 0:
+                            percent = int((current / total) * 100)
+                            percent = min(100, max(0, percent))
+                            pb.progress(percent, text=f"[{current}/{total}] {name} 처리 중... ({percent}%)")
+                            st_status.update(label=f"진행 중: {name}", state="running")
+                            st.write(f"[{current}/{total}] {name} 처리 완료 ({percent}%)")
+
+                    orchestrator = PipelineOrchestrator()
+                    orchestrator.update_file_parser(f.name, active_parser, progress_callback=single_file_sync_callback)
+                    progress_bar.progress(100, text="동기화 완료")
+                    status.update(label="개별 동기화 및 재색인 완료", state="complete", expanded=False)
+
+                initialize_rag_system.clear()
+                st.toast(f"동기화 완료: {f.name}")
+                time.sleep(0.5)
+                progress_bar.empty()
+                st.rerun()
+
+            if r_col8.button("🗑️", key=f"del_btn_{i}", help=f"'{f.name}' 삭제") and f.exists():
                 f.unlink()
                 st.toast(f"파일 삭제됨: {f.name}")
                 if auto_sync:
@@ -289,6 +382,56 @@ def show_admin_dialog(db_manager):  # noqa: C901
                 else:
                     time.sleep(0.5)
                     st.session_state.should_rerun_app = True  # Set flag instead of direct rerun
+
+    pending = st.session_state.get("parser_change_pending")
+    if pending:
+        st.warning(
+            "파서 변경 확인: 다음 파일들의 파서를 변경하시겠습니까? "
+            "변경 시 해당 파일들은 새로운 파서 규격으로 즉시 재색인됩니다."
+        )
+
+        change_details = []
+        for file_name, new_parser in pending.items():
+            file_chunks = db_manager.get_source_chunks(file_name)
+            old_parser = "manual"
+            if file_chunks:
+                old_parser = file_chunks[0].get("metadata", {}).get("parser", "manual")
+            change_details.append(f"- {file_name}: {old_parser} -> {new_parser}")
+
+        st.markdown("\n".join(change_details))
+
+        col_confirm, col_cancel = st.columns(2)
+        with col_confirm:
+            if st.button("예, 변경 및 재색인 실행", key="confirm_parser_change_btn", use_container_width=True):
+                pending_copy = pending.copy()
+                st.session_state.parser_change_pending = None
+                progress_bar = st.progress(0)
+
+                with st.status("지정된 파일들의 파서 전환 및 재색인 중...", expanded=True) as status:
+                    def multi_file_sync_callback(current, total, name, pb=progress_bar, st_status=status):
+                        if total > 0:
+                            percent = int((current / total) * 100)
+                            percent = min(100, max(0, percent))
+                            pb.progress(percent, text=f"[{current}/{total}] {name} 처리 중... ({percent}%)")
+                            st_status.update(label=f"진행 중: {name}", state="running")
+
+                    orchestrator = PipelineOrchestrator()
+                    orchestrator.update_multiple_file_parsers(
+                        pending_copy, progress_callback=multi_file_sync_callback
+                    )
+                    progress_bar.progress(100, text="파서 전환 완료")
+                    status.update(label="파서 전환 및 재색인 완료", state="complete", expanded=False)
+
+                initialize_rag_system.clear()
+                st.toast("선택한 파일들의 파서가 성공적으로 전환되었습니다.")
+                time.sleep(0.5)
+                progress_bar.empty()
+                st.rerun()
+
+        with col_cancel:
+            if st.button("취소", key="cancel_parser_change_btn", use_container_width=True):
+                st.session_state.parser_change_pending = None
+                st.rerun()
 
     st.divider()
     if st.button("관리 시스템 종료 (닫기)", use_container_width=True):

--- a/src/app.py
+++ b/src/app.py
@@ -1,7 +1,9 @@
+import json
 import logging
 import math
 import os
 import time
+from pathlib import Path
 
 import streamlit as st
 from dotenv import load_dotenv
@@ -95,28 +97,170 @@ if "show_expert_mode" not in st.session_state:
 
 def reset_chunks_viewer():
     st.session_state.dialog_chunks_file_to_show = None
+    if "chunk_viewer_page" in st.session_state:
+        st.session_state.chunk_viewer_page = 0
     st.session_state.admin_active = True
     st.session_state.should_rerun_app = True
 
 
 @st.dialog("문서 청크 목록 및 메타데이터 상세", width="large", on_dismiss=reset_chunks_viewer)
-def show_chunks_viewer_dialog(file_name, db_manager):
+def show_chunks_viewer_dialog(file_name, db_manager):  # noqa: C901
     st.subheader(f"문서명: {file_name}")
-    chunks = db_manager.get_source_chunks(file_name)
-    st.write(f"총 청크 수: {len(chunks)}개")
 
-    with st.container(height=500):
+    # 1. 파일명에 해당하는 해시(source_id) 구하기
+    import unicodedata
+
+    orchestrator = PipelineOrchestrator()
+    manifest = orchestrator._load_manifest()
+    manifest_files = manifest.get("files", {})
+
+    target_hash = None
+    normalized_file_name = unicodedata.normalize("NFC", file_name)
+    for rel_path, info in manifest_files.items():
+        normalized_rel_name = unicodedata.normalize("NFC", Path(rel_path).name)
+        if normalized_rel_name == normalized_file_name:
+            target_hash = info.get("hash")
+            break
+
+    # 2. 전처리 JSON 파일에서 자식 chunk_id와 부모 parent_text의 맵 빌드
+    parent_text_map = {}
+    if target_hash:
+        from src.utils.paths import PROCESSED_DATA_DIR
+
+        json_path = PROCESSED_DATA_DIR / f"{target_hash}.json"
+        if json_path.exists():
+            try:
+                with open(json_path, encoding="utf-8") as jf:
+                    processed_data = json.load(jf)
+                for parent_item in processed_data:
+                    p_text = parent_item.get("parent_text", "")
+                    for child in parent_item.get("children", []):
+                        c_id = child.get("chunk_id")
+                        if c_id:
+                            parent_text_map[c_id] = p_text
+            except Exception as json_e:
+                logger.error(f"전처리 JSON 파일 로드 실패: {json_e}")
+
+    # 3. ChromaDB 청크 목록 조회 및 페이징 구성
+    chunks = db_manager.get_source_chunks(file_name)
+    total_chunks = len(chunks)
+    st.write(f"총 청크 수: {total_chunks}개")
+
+    with st.container(height=550):
         if not chunks:
             st.info("이 문서에 저장된 청크 데이터가 없습니다.")
         else:
-            for i, chunk in enumerate(chunks):
-                st.markdown(f"### Chunk {i + 1} (ID: `{chunk['id']}`)")
-                st.text_area(
-                    "청크 내용", chunk["content"], height=150, key=f"chunk_content_{file_name}_{i}", disabled=True
+            page_size = 5
+            total_pages = max(1, math.ceil(total_chunks / page_size))
+
+            if "chunk_viewer_page" not in st.session_state:
+                st.session_state.chunk_viewer_page = 0
+
+            current_page = st.session_state.chunk_viewer_page
+            if current_page >= total_pages:
+                current_page = total_pages - 1
+                st.session_state.chunk_viewer_page = current_page
+            elif current_page < 0:
+                current_page = 0
+                st.session_state.chunk_viewer_page = current_page
+
+            start_idx = current_page * page_size
+            end_idx = min(start_idx + page_size, total_chunks)
+
+            st.write(f"표시 중: {start_idx + 1} ~ {end_idx} 번 청크")
+
+            for idx in range(start_idx, end_idx):
+                chunk = chunks[idx]
+                c_id = chunk["id"]
+                st.markdown(f"### Chunk {idx + 1} (ID: `{c_id}`)")
+                st.write("**청크 내용 (자식 텍스트)**")
+                import html
+                escaped_content = html.escape(chunk["content"])
+                st.markdown(
+                    f"""<div style="
+                        background-color: rgba(151,166,195,0.08);
+                        padding: 12px;
+                        border-radius: 6px;
+                        border: 1px solid rgba(151,166,195,0.2);
+                        max-height: 180px;
+                        overflow-y: auto;
+                        white-space: pre-wrap;
+                        font-size: 0.95rem;
+                        line-height: 1.5;
+                        color: #f0f2f6;
+                        margin-bottom: 10px;
+                    ">{escaped_content}</div>""",
+                    unsafe_allow_html=True,
                 )
-                st.markdown("**메타데이터**")
-                st.json(chunk["metadata"])
+
+                # 매핑된 상위 부모 텍스트가 있을 경우 익스팬더로 표시
+                parent_text = parent_text_map.get(c_id)
+                if parent_text:
+                    with st.expander("상위 부모 문맥 (Parent Context)"):
+                        escaped_parent = html.escape(parent_text)
+                        st.markdown(
+                            f"""<div style="
+                                background-color: rgba(151,166,195,0.04);
+                                padding: 12px;
+                                border-radius: 6px;
+                                border: 1px solid rgba(151,166,195,0.15);
+                                max-height: 250px;
+                                overflow-y: auto;
+                                white-space: pre-wrap;
+                                font-size: 0.95rem;
+                                line-height: 1.5;
+                                color: #e0e2e6;
+                            ">{escaped_parent}</div>""",
+                            unsafe_allow_html=True,
+                        )
+
+                # 메타데이터 상세 정보는 기본으로 접힌 상태로 렌더링
+                with st.expander("청크 메타데이터 상세 (Metadata)"):
+                    st.json(chunk["metadata"])
+
                 st.divider()
+
+            # 숫자 버튼형 페이징 네비게이션 구성 (최대 10개 표시 슬라이딩 윈도우)
+            max_visible = 10
+            start_page = max(0, current_page - max_visible // 2)
+            end_page = min(total_pages, start_page + max_visible)
+            if end_page - start_page < max_visible:
+                start_page = max(0, end_page - max_visible)
+
+            cols_width = [1.2] + [1.0] * (end_page - start_page) + [1.2]
+            cols = st.columns(cols_width)
+
+            with cols[0]:
+                if st.button(
+                    "이전",
+                    disabled=(current_page == 0),
+                    use_container_width=True,
+                    key="chunk_prev_btn",
+                ):
+                    st.session_state.chunk_viewer_page = current_page - 1
+                    st.rerun()
+
+            for idx, page_idx in enumerate(range(start_page, end_page)):
+                with cols[idx + 1]:
+                    btn_type = "primary" if page_idx == current_page else "secondary"
+                    if st.button(
+                        f"{page_idx + 1}",
+                        type=btn_type,
+                        use_container_width=True,
+                        key=f"chunk_page_btn_{page_idx}",
+                    ):
+                        st.session_state.chunk_viewer_page = page_idx
+                        st.rerun()
+
+            with cols[-1]:
+                if st.button(
+                    "다음",
+                    disabled=(current_page == total_pages - 1),
+                    use_container_width=True,
+                    key="chunk_next_btn",
+                ):
+                    st.session_state.chunk_viewer_page = current_page + 1
+                    st.rerun()
 
     if st.button("닫기", use_container_width=True, key="close_chunks_viewer_btn"):
         reset_chunks_viewer()

--- a/src/app.py
+++ b/src/app.py
@@ -446,6 +446,7 @@ def show_admin_dialog(db_manager):  # noqa: C901
 
             # 적용 파서 식별 (매니페스트 우선 조회, 차선으로 ChromaDB 조회)
             import unicodedata
+
             rel_path = unicodedata.normalize("NFC", str(f.relative_to(RAW_DATA_DIR)))
 
             r_col2.text(rel_path)  # 파일명 대신 상대 경로 표시
@@ -544,7 +545,6 @@ def show_admin_dialog(db_manager):  # noqa: C901
                 st.rerun()
 
             if r_col8.button("🗑️", key=f"del_btn_{i}", help=f"'{f.name}' 삭제") and f.exists():
-
                 f.unlink()
                 st.toast(f"파일 삭제됨: {f.name}")
                 if auto_sync:

--- a/src/app.py
+++ b/src/app.py
@@ -175,6 +175,7 @@ def show_chunks_viewer_dialog(file_name, db_manager):  # noqa: C901
                 st.markdown(f"### Chunk {idx + 1} (ID: `{c_id}`)")
                 st.write("**청크 내용 (자식 텍스트)**")
                 import html
+
                 escaped_content = html.escape(chunk["content"])
                 st.markdown(
                     f"""<div style="
@@ -319,6 +320,7 @@ def show_admin_dialog(db_manager):  # noqa: C901
         progress_bar = st.progress(0)
 
         with st.status("데이터베이스 동기화 중...", expanded=True) as status:
+
             def sync_callback(current, total, file_name, pb=progress_bar, st_status=status):
                 if total > 0:
                     percent = int((current / total) * 100)
@@ -426,8 +428,11 @@ def show_admin_dialog(db_manager):  # noqa: C901
             r_col3.write(format_size(f.stat().st_size))
 
             # 적용 파서 식별 (매니페스트 우선 조회, 차선으로 ChromaDB 조회)
-            rel_path = str(f.relative_to(RAW_DATA_DIR))
-            file_manifest_info = manifest_files.get(rel_path, {})
+            import unicodedata
+
+            rel_path = unicodedata.normalize("NFC", str(f.relative_to(RAW_DATA_DIR)))
+            normalized_manifest_files = {unicodedata.normalize("NFC", k): v for k, v in manifest_files.items()}
+            file_manifest_info = normalized_manifest_files.get(rel_path, {})
             parser_name = file_manifest_info.get("parser_type")
 
             chunks = db_manager.get_source_chunks(f.name)
@@ -499,6 +504,7 @@ def show_admin_dialog(db_manager):  # noqa: C901
 
                 progress_bar = st.progress(0)
                 with st.status(f"{f.name} 개별 동기화 중...", expanded=True) as status:
+
                     def single_file_sync_callback(current, total, name, pb=progress_bar, st_status=status):
                         if total > 0:
                             percent = int((current / total) * 100)
@@ -525,7 +531,7 @@ def show_admin_dialog(db_manager):  # noqa: C901
                     trigger_sync(force=False)
                 else:
                     time.sleep(0.5)
-                    st.session_state.should_rerun_app = True  # Set flag instead of direct rerun
+                    st.rerun()
 
     pending = st.session_state.get("parser_change_pending")
     if pending:
@@ -552,6 +558,7 @@ def show_admin_dialog(db_manager):  # noqa: C901
                 progress_bar = st.progress(0)
 
                 with st.status("지정된 파일들의 파서 전환 및 재색인 중...", expanded=True) as status:
+
                     def multi_file_sync_callback(current, total, name, pb=progress_bar, st_status=status):
                         if total > 0:
                             percent = int((current / total) * 100)
@@ -560,9 +567,7 @@ def show_admin_dialog(db_manager):  # noqa: C901
                             st_status.update(label=f"진행 중: {name}", state="running")
 
                     orchestrator = PipelineOrchestrator()
-                    orchestrator.update_multiple_file_parsers(
-                        pending_copy, progress_callback=multi_file_sync_callback
-                    )
+                    orchestrator.update_multiple_file_parsers(pending_copy, progress_callback=multi_file_sync_callback)
                     progress_bar.progress(100, text="파서 전환 완료")
                     status.update(label="파서 전환 및 재색인 완료", state="complete", expanded=False)
 
@@ -580,7 +585,7 @@ def show_admin_dialog(db_manager):  # noqa: C901
     st.divider()
     if st.button("관리 시스템 종료 (닫기)", use_container_width=True):
         st.session_state.admin_active = False
-        st.session_state.should_rerun_app = True  # Set flag instead of direct rerun
+        st.rerun()
 
 
 # --- 4. RAG 시스템 초기화 (캐싱) ---

--- a/src/app.py
+++ b/src/app.py
@@ -62,6 +62,8 @@ if "admin_active" not in st.session_state:
     st.session_state.admin_active = False
 if "dialog_doc_to_show" not in st.session_state:
     st.session_state.dialog_doc_to_show = None
+if "dialog_chunks_file_to_show" not in st.session_state:
+    st.session_state.dialog_chunks_file_to_show = None
 if "is_generating" not in st.session_state:
     st.session_state.is_generating = False
 if "should_rerun_app" not in st.session_state:
@@ -87,6 +89,36 @@ if "show_expert_mode" not in st.session_state:
 
 
 # --- 3. 팝업 다이얼로그 정의 ---
+
+
+def reset_chunks_viewer():
+    st.session_state.dialog_chunks_file_to_show = None
+    st.session_state.admin_active = True
+    st.session_state.should_rerun_app = True
+
+
+@st.dialog("문서 청크 목록 및 메타데이터 상세", width="large", on_dismiss=reset_chunks_viewer)
+def show_chunks_viewer_dialog(file_name, db_manager):
+    st.subheader(f"문서명: {file_name}")
+    chunks = db_manager.get_source_chunks(file_name)
+    st.write(f"총 청크 수: {len(chunks)}개")
+
+    with st.container(height=500):
+        if not chunks:
+            st.info("이 문서에 저장된 청크 데이터가 없습니다.")
+        else:
+            for i, chunk in enumerate(chunks):
+                st.markdown(f"### Chunk {i + 1} (ID: `{chunk['id']}`)")
+                st.text_area(
+                    "청크 내용", chunk["content"], height=150, key=f"chunk_content_{file_name}_{i}", disabled=True
+                )
+                st.markdown("**메타데이터**")
+                st.json(chunk["metadata"])
+                st.divider()
+
+    if st.button("닫기", use_container_width=True, key="close_chunks_viewer_btn"):
+        reset_chunks_viewer()
+        st.rerun()
 
 
 # [문서 원문 보기]
@@ -117,27 +149,48 @@ def show_admin_dialog(db_manager):  # noqa: C901
     st.markdown("지식 베이스(RAW_DATA) 관리 및 데이터베이스 동기화를 수행합니다.")
 
     # 상단 옵션 영역
-    col_opt1, _ = st.columns([1, 1])
+    col_opt1, col_opt2 = st.columns([1, 1])
     with col_opt1:
         auto_sync = st.checkbox(
             "파일 업로드/삭제 후 자동 동기화 실행",
             value=True,
             help="체크 시 별도의 Sync 버튼 클릭 없이 즉시 DB에 반영합니다.",
         )
+    with col_opt2:
+        default_parser_idx = 0 if settings.PARSER_TYPE.lower() == "manual" else 1
+        parser_type = st.radio(
+            "적용 파서 선택",
+            options=["manual", "docling"],
+            index=default_parser_idx,
+            horizontal=True,
+            help="동기화 파이프라인에서 사용할 PDF 파서 전략을 지정합니다.",
+        )
 
     st.divider()
 
     # 공통 동기화 로직 함수
     def trigger_sync(force=False):
+        progress_bar = st.progress(0)
+
+        def sync_callback(current, total, file_name):
+            if total > 0:
+                percent = int((current / total) * 100)
+                percent = min(100, max(0, percent))
+                progress_bar.progress(percent, text=f"[{current}/{total}] {file_name} 처리 중... ({percent}%)")
+            else:
+                progress_bar.progress(0, text="대기 중...")
+
         with st.status("데이터베이스 동기화 중...", expanded=True) as status:
             # 싱글톤 인스턴스 사용 (불필요한 모델 로드 방지)
             orchestrator = PipelineOrchestrator()
-            orchestrator.run_ingestion(force=force)
+            orchestrator.run_ingestion(force=force, parser_type=parser_type, progress_callback=sync_callback)
+            progress_bar.progress(100, text="모든 파일 처리 완료 (100%)")
             status.update(label="동기화 완료", state="complete", expanded=False)
         # 캐시된 RAG 시스템(db_manager, rag_chain)을 재초기화하여 리셋된 컬렉션을 반영
         initialize_rag_system.clear()
         st.success("DB 동기화 완료")
         time.sleep(0.5)
+        progress_bar.empty()
         st.rerun()
 
     # 상단 영역: 업로드 및 동기화
@@ -196,25 +249,39 @@ def show_admin_dialog(db_manager):  # noqa: C901
     if not current_files:
         st.info("현재 등록된 문서가 없습니다.")
     else:
-        h_col1, h_col2, h_col3, h_col4, h_col5 = st.columns([0.2, 3.0, 0.8, 0.6, 0.6])
+        h_col1, h_col2, h_col3, h_col4, h_col5, h_col6 = st.columns([0.2, 2.5, 0.8, 0.8, 0.6, 0.6])
         h_col1.write("**No**")
         h_col2.write("**파일명**")
         h_col3.write("**크기**")
-        h_col4.write("**청크**")
-        h_col5.write("**삭제**")
+        h_col4.write("**적용 파서**")
+        h_col5.write("**청크**")
+        h_col6.write("**삭제**")
         st.markdown(
             "<hr style='margin: 0px 0px 10px 0px; border: 0.5px solid rgba(151,166,195,0.2);'>",
             unsafe_allow_html=True,
         )
 
         for i, f in enumerate(current_files):
-            r_col1, r_col2, r_col3, r_col4, r_col5 = st.columns([0.2, 3.0, 0.8, 0.6, 0.6])
+            r_col1, r_col2, r_col3, r_col4, r_col5, r_col6 = st.columns([0.2, 2.5, 0.8, 0.8, 0.6, 0.6])
             r_col1.write(f"{i + 1}")
             r_col2.text(f.name)
             r_col3.write(format_size(f.stat().st_size))
-            chunk_count = db_manager.get_source_count(f.name)
-            r_col4.write(f"{chunk_count}")
-            if r_col5.button("🗑️", key=f"del_btn_{i}", help=f"'{f.name}' 삭제") and f.exists():
+
+            # 적용 파서 식별
+            chunks = db_manager.get_source_chunks(f.name)
+            parser_name = "-"
+            if chunks:
+                parser_name = chunks[0].get("metadata", {}).get("parser", "manual")
+            r_col4.write(f"`{parser_name}`")
+
+            chunk_count = len(chunks)
+            if r_col5.button(f"{chunk_count} 🔍", key=f"view_chunks_{i}", help="청크 상세 내용 보기"):
+                st.session_state.dialog_chunks_file_to_show = f.name
+                st.session_state.admin_active = False
+                st.session_state.should_rerun_app = True
+                st.rerun()
+
+            if r_col6.button("🗑️", key=f"del_btn_{i}", help=f"'{f.name}' 삭제") and f.exists():
                 f.unlink()
                 st.toast(f"파일 삭제됨: {f.name}")
                 if auto_sync:
@@ -362,6 +429,9 @@ with st.sidebar:
 # --- 6. 다이얼로그 활성화 제어 ---
 if st.session_state.get("admin_active", False):
     show_admin_dialog(db_manager)
+
+if st.session_state.get("dialog_chunks_file_to_show"):
+    show_chunks_viewer_dialog(st.session_state.dialog_chunks_file_to_show, db_manager)
 
 
 # --- UI 스트리밍 핸들러 ---

--- a/src/common/constants.py
+++ b/src/common/constants.py
@@ -10,6 +10,7 @@ class MetadataFields:
     SRC_NAME: Final[str] = "src_name"
     RELATIVE_PATH: Final[str] = "relative_path"
     PARSER_TYPE: Final[str] = "parser_type"
+    PARSER: Final[str] = "parser"
     DOC_TYPE: Final[str] = "doc_type"
     PG_NUM: Final[str] = "pg_num"
     CATEGORY: Final[str] = "category"

--- a/src/data/parser.py
+++ b/src/data/parser.py
@@ -87,7 +87,7 @@ class ManualParser:
                     MetadataFields.PG_NUM: page,
                     MetadataFields.DOC_TYPE: self.extension,
                     MetadataFields.CATEGORY: self.category,
-                    "parser": self.parser_type,
+                    MetadataFields.PARSER: self.parser_type,
                 },
             }
         )

--- a/src/data/parser.py
+++ b/src/data/parser.py
@@ -85,6 +85,7 @@ class ManualParser:
                     MetadataFields.PG_NUM: page,
                     MetadataFields.DOC_TYPE: self.extension,
                     MetadataFields.CATEGORY: self.category,
+                    "parser": self.parser_type,
                 },
             }
         )

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -9,8 +9,6 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
-from tqdm import tqdm
-
 from src.common.config import settings
 from src.common.constants import MetadataFields
 from src.core.cache import SemanticCache
@@ -160,7 +158,9 @@ class IngestionPipeline:
             files.extend(filtered_files)
         return files
 
-    def process_and_chunk(self, files: list[Path], progress_callback=None) -> list[dict[str, Any]]:
+    def process_and_chunk(  # noqa: C901
+        self, files: list[Path], progress_callback=None, file_parser_types: dict[str, str] | None = None
+    ) -> list[dict[str, Any]]:
         all_hierarchical_data = []
         total_files = len(files)
         for idx, file_path in enumerate(files):
@@ -171,7 +171,21 @@ class IngestionPipeline:
                     logger.error(f"진행 상황 콜백 호출 실패: {cb_e}")
             try:
                 # 1. 파일 확장자에 따른 전략 동적 선택 및 파싱
-                active_strategy = self.strategy if file_path.suffix.lower() == ".pdf" else MarkdownParserStrategy()
+                if file_path.suffix.lower() == ".pdf":
+                    rel_path = str(file_path.relative_to(RAW_DATA_DIR))
+                    file_parser = (file_parser_types or {}).get(rel_path, "manual").lower()
+                    if file_parser == "docling":
+                        try:
+                            import docling  # noqa: F401
+
+                            active_strategy = DoclingPDFParserStrategy()
+                        except ImportError:
+                            logger.error("docling 라이브러리가 없어 manual 전략으로 대체합니다.")
+                            active_strategy = ManualParserStrategy()
+                    else:
+                        active_strategy = ManualParserStrategy()
+                else:
+                    active_strategy = MarkdownParserStrategy()
 
                 sections = active_strategy.parse(file_path)
 
@@ -257,18 +271,19 @@ class IngestionPipeline:
         DB, 캐시 및 가공된 JSON 파일에서 삭제된 데이터를 제거합니다.
         (BM25Manager는 processed_dir의 모든 json을 읽으므로 물리적 파일 삭제가 곧 정합성임)
         """
-        if not source_ids_to_delete:
+        valid_ids = [sid for sid in source_ids_to_delete if sid]
+        if not valid_ids:
             return
 
-        logger.info(f"데이터 정합성 검증: {len(source_ids_to_delete)}개 소스 ID에 대한 클린업을 수행합니다.")
+        logger.info(f"데이터 정합성 검증: {len(valid_ids)}개 소스 ID에 대한 클린업을 수행합니다.")
 
         # 1. 벡터 DB 데이터 삭제
-        self.db_manager.delete_documents(where={"source_id": {"$in": source_ids_to_delete}})
+        self.db_manager.delete_documents(where={"source_id": {"$in": valid_ids}})
         logger.info("   - ChromaDB 벡터 데이터 삭제 완료")
 
         # 2. 물리적 캐시 및 JSON 파일 삭제 (강화된 클린업)
         deleted_count = 0
-        for sid in source_ids_to_delete:
+        for sid in valid_ids:
             # 파싱 캐시 삭제
             cache_file = CACHE_DIR / f"{sid}_parsed.pkl"
             if cache_file.exists():
@@ -329,21 +344,33 @@ class PipelineOrchestrator:
             self._initialized = True
             logger.info("PipelineOrchestrator 초기화 완료.")
 
-    def _load_manifest(self) -> dict[str, str]:
-        """manifest.json 파일을 로드합니다. 파일이 없거나 손상된 경우, 빈 dict를 반환합니다."""
+    def _load_manifest(self) -> dict[str, Any]:
+        """manifest.json 파일을 로드합니다. 파일이 없거나 손상된 경우, 빈 2.0 매니페스트를 반환합니다."""
+        default_manifest = {"version": "2.0", "global_parser_type": self.parser_type, "files": {}}
         if not self.manifest_path.exists():
             logger.warning("Manifest 파일이 없어 전체 재색인을 수행합니다.")
-            return {}
+            return default_manifest
         try:
             with open(self.manifest_path, encoding="utf-8") as f:
-                return json.load(f)
+                data = json.load(f)
+
+            # 하위 호환성 처리 (1.0 규격인 경우 자동 변환)
+            if not isinstance(data, dict) or "version" not in data:
+                logger.info("이전 규격(1.0)의 Manifest가 감지되어 2.0 규격으로 자동 전환합니다.")
+                files_converted = {}
+                if isinstance(data, dict):
+                    for k, v in data.items():
+                        if isinstance(v, str):
+                            files_converted[k] = {"hash": v, "parser_type": self.parser_type}
+                data = {"version": "2.0", "global_parser_type": self.parser_type, "files": files_converted}
+            return data
         except (json.JSONDecodeError, FileNotFoundError):
             logger.warning("Manifest 파일이 손상되었거나 찾을 수 없어 전체 재색인을 수행합니다.")
             if self.manifest_path.exists():
                 self.manifest_path.unlink()
-            return {}
+            return default_manifest
 
-    def _save_manifest(self, manifest: dict[str, str]):
+    def _save_manifest(self, manifest: dict[str, Any]):
         """처리 완료 후 새로운 manifest 상태를 저장합니다."""
         try:
             with open(self.manifest_path, "w", encoding="utf-8") as f:
@@ -370,26 +397,44 @@ class PipelineOrchestrator:
         return ManualParserStrategy()
 
     def _calculate_delta(
-        self, all_files: list[Path], old_manifest: dict[str, str]
-    ) -> tuple[list[Path], list[str], dict[str, str]]:
+        self, all_files: list[Path], old_manifest: dict[str, Any]
+    ) -> tuple[list[Path], list[str], dict[str, Any]]:
         """현재 파일 상태와 이전 상태를 비교하여 변경 사항(Delta)을 계산합니다."""
-        new_manifest = {str(f.relative_to(RAW_DATA_DIR)): generate_file_hash(f, self.parser_type) for f in all_files}
+        old_files = old_manifest.get("files", {})
 
-        files_to_process_relative = [p for p, h in new_manifest.items() if old_manifest.get(p) != h]
-        files_to_process = [RAW_DATA_DIR / p for p in files_to_process_relative]
+        new_files = {}
+        for f in all_files:
+            rel_path = str(f.relative_to(RAW_DATA_DIR))
+            old_info = old_files.get(rel_path, {})
+            file_parser_type = old_info.get("parser_type", self.parser_type)
+            h = generate_file_hash(f, file_parser_type)
+            new_files[rel_path] = {"hash": h, "parser_type": file_parser_type}
 
-        source_ids_to_delete = [
-            h for p, h in old_manifest.items() if p not in new_manifest or old_manifest[p] != new_manifest[p]
-        ]
+        new_manifest = {"version": "2.0", "global_parser_type": self.parser_type, "files": new_files}
+
+        files_to_process = []
+        for rel_path, info in new_files.items():
+            old_info = old_files.get(rel_path)
+            if not old_info or old_info.get("hash") != info["hash"]:
+                files_to_process.append(RAW_DATA_DIR / rel_path)
+
+        source_ids_to_delete = []
+        for rel_path, old_info in old_files.items():
+            new_info = new_files.get(rel_path)
+            if not new_info or old_info.get("hash") != new_info["hash"]:
+                old_hash = old_info.get("hash")
+                if old_hash:
+                    source_ids_to_delete.append(old_hash)
 
         return files_to_process, source_ids_to_delete, new_manifest
 
-    def _process_changes(
+    def _process_changes(  # noqa: C901
         self,
         files_to_process: list[Path],
         source_ids_to_delete: list[str],
         session: Any,
         progress_callback=None,
+        new_manifest: dict[str, Any] | None = None,
     ):
         """도출된 변경 사항(DB 삭제, 파싱, 업서트, 인덱스 갱신)을 순차적으로 수행합니다."""
         if files_to_process or source_ids_to_delete:
@@ -403,8 +448,13 @@ class PipelineOrchestrator:
 
         if files_to_process:
             with session.trace_step("parse_and_chunk") as step:
+                file_parser_types = {}
+                if new_manifest and "files" in new_manifest:
+                    for rel_path, info in new_manifest["files"].items():
+                        file_parser_types[rel_path] = info.get("parser_type", self.parser_type)
+
                 processed_data = self.ingestion_pipeline.process_and_chunk(
-                    files_to_process, progress_callback=progress_callback
+                    files_to_process, progress_callback=progress_callback, file_parser_types=file_parser_types
                 )
                 step["parent_chunk_count"] = len(processed_data)
 
@@ -412,6 +462,16 @@ class PipelineOrchestrator:
                 with session.trace_step("save_json") as step:
                     save_paths = self.ingestion_pipeline.save_processed_data(processed_data)
                     step["saved_files"] = [p.name for p in save_paths]
+
+                if progress_callback:
+                    try:
+                        progress_callback(
+                            len(files_to_process),
+                            len(files_to_process),
+                            "임베딩 변환 및 벡터 적재 중 (시간이 소요될 수 있습니다)"
+                        )
+                    except Exception as cb_e:
+                        logger.error(f"진행 상황 콜백 호출 실패: {cb_e}")
 
                 with session.trace_step("db_upsert"):
                     self.ingestion_pipeline.upsert_to_db(processed_data)
@@ -426,7 +486,13 @@ class PipelineOrchestrator:
                 except Exception as e:
                     step["status"] = f"failed: {e}"
 
-    def run_ingestion(self, force: bool = False, parser_type: str = None, progress_callback=None):
+    def run_ingestion(  # noqa: C901
+        self,
+        force: bool = False,
+        parser_type: str | None = None,
+        progress_callback=None,
+        target_files: list[Path] | None = None,
+    ):
         """전체 데이터 구축 파이프라인 실행"""
         if parser_type:
             parser_type_lower = parser_type.lower()
@@ -471,13 +537,52 @@ class PipelineOrchestrator:
 
                     files_to_process = all_files
                     source_ids_to_delete = []  # 이미 물리적으로 모두 삭제했으므로 부분 삭제 프로세스는 건너뜀
-                    new_manifest = {
-                        str(f.relative_to(RAW_DATA_DIR)): generate_file_hash(f, self.parser_type) for f in all_files
-                    }
+
+                    new_files = {}
+                    for f in all_files:
+                        rel_path = str(f.relative_to(RAW_DATA_DIR))
+                        new_files[rel_path] = {
+                            "hash": generate_file_hash(f, self.parser_type),
+                            "parser_type": self.parser_type,
+                        }
+                    new_manifest = {"version": "2.0", "global_parser_type": self.parser_type, "files": new_files}
                 else:
                     files_to_process, source_ids_to_delete, new_manifest = self._calculate_delta(
                         all_files, old_manifest
                     )
+
+                # target_files 부분 동기화 필터링 적용
+                if target_files is not None:
+                    target_paths = {p.resolve() for p in target_files}
+                    filtered_files_to_process = [
+                        f for f in files_to_process if f.resolve() in target_paths
+                    ]
+
+                    # target_files에 해당하지 않는 문서들의 구 해시값은 delete 목록에서 보존
+                    target_names = {p.name for p in target_files}
+                    filtered_source_ids_to_delete = []
+                    for sid in source_ids_to_delete:
+                        old_files = old_manifest.get("files", {})
+                        is_target = False
+                        for rel_path, info in old_files.items():
+                            if info.get("hash") == sid and Path(rel_path).name in target_names:
+                                is_target = True
+                                break
+                        if is_target:
+                            filtered_source_ids_to_delete.append(sid)
+
+                    # new_manifest 내에서 처리되지 않은 문서의 메타데이터 보존
+                    if new_manifest and "files" in new_manifest:
+                        for rel_path in list(new_manifest["files"].keys()):
+                            full_path = RAW_DATA_DIR / rel_path
+                            if full_path.resolve() not in target_paths:
+                                if rel_path in old_manifest.get("files", {}):
+                                    new_manifest["files"][rel_path] = old_manifest["files"][rel_path]
+                                else:
+                                    new_manifest["files"].pop(rel_path, None)
+
+                    files_to_process = filtered_files_to_process
+                    source_ids_to_delete = filtered_source_ids_to_delete
 
                 step["total_files"] = len(all_files)
                 step["files_to_process"] = len(files_to_process)
@@ -501,12 +606,104 @@ class PipelineOrchestrator:
                 source_ids_to_delete,
                 session,
                 progress_callback=progress_callback,
+                new_manifest=new_manifest,
             )
 
             with session.trace_step("update_manifest"):
                 self._save_manifest(new_manifest)
 
         logger.info("데이터 구축 파이프라인 작업이 완료되었습니다.")
+
+    def update_file_parser(self, file_name: str, new_parser_type: str, progress_callback=None):
+        """특정 파일의 동기화 파서 타입을 변경하고, 해당 파일에 한해 즉각 재색인을 실행합니다."""
+        new_parser_lower = new_parser_type.lower()
+        old_manifest = self._load_manifest()
+        old_files = old_manifest.get("files", {})
+
+        target_rel_path = None
+        for rel_path in old_files:
+            if Path(rel_path).name == file_name or rel_path == file_name:
+                target_rel_path = rel_path
+                break
+
+        if not target_rel_path:
+            for f in self.ingestion_pipeline.scan_files():
+                if f.name == file_name:
+                    target_rel_path = str(f.relative_to(RAW_DATA_DIR))
+                    break
+
+        if not target_rel_path:
+            logger.warning(f"파서 변경 대상 파일을 찾을 수 없습니다: {file_name}")
+            return
+
+        logger.info(f"파일 {target_rel_path}의 파서를 {new_parser_lower}로 변경합니다.")
+
+        if target_rel_path not in old_files:
+            old_files[target_rel_path] = {}
+        old_files[target_rel_path]["hash"] = ""
+        old_files[target_rel_path]["parser_type"] = new_parser_lower
+
+        old_manifest["files"] = old_files
+        self._save_manifest(old_manifest)
+
+        # target_files를 전달하여 해당 파일만 동기화하도록 강제
+        target_path = RAW_DATA_DIR / target_rel_path
+        self.run_ingestion(
+            force=False, progress_callback=progress_callback, target_files=[target_path]
+        )
+
+    def update_multiple_file_parsers(self, file_parser_map: dict[str, str], progress_callback=None):  # noqa: C901
+        """복수 파일의 동기화 파서 타입을 한꺼번에 변경하고, 대상 파일들을 즉각 재색인합니다."""
+        old_manifest = self._load_manifest()
+        old_files = old_manifest.get("files", {})
+
+        updated_count = 0
+        for file_name, new_parser in file_parser_map.items():
+            new_parser_lower = new_parser.lower()
+
+            target_rel_path = None
+            for rel_path in old_files:
+                if Path(rel_path).name == file_name or rel_path == file_name:
+                    target_rel_path = rel_path
+                    break
+
+            if not target_rel_path:
+                for f in self.ingestion_pipeline.scan_files():
+                    if f.name == file_name:
+                        target_rel_path = str(f.relative_to(RAW_DATA_DIR))
+                        break
+
+            if target_rel_path:
+                logger.info(f"파일 {target_rel_path}의 파서를 {new_parser_lower}로 변경 등록합니다.")
+                if target_rel_path not in old_files:
+                    old_files[target_rel_path] = {}
+                old_files[target_rel_path]["hash"] = ""
+                old_files[target_rel_path]["parser_type"] = new_parser_lower
+                updated_count += 1
+
+        if updated_count > 0:
+            old_manifest["files"] = old_files
+            self._save_manifest(old_manifest)
+
+            # 변경된 파일들에 대해서만 일괄 부분 동기화 가동
+            target_paths = []
+            for file_name in file_parser_map:
+                target_rel_path = None
+                for rel_path in old_files:
+                    if Path(rel_path).name == file_name or rel_path == file_name:
+                        target_rel_path = rel_path
+                        break
+                if not target_rel_path:
+                    for f in self.ingestion_pipeline.scan_files():
+                        if f.name == file_name:
+                            target_rel_path = str(f.relative_to(RAW_DATA_DIR))
+                            break
+                if target_rel_path:
+                    target_paths.append(RAW_DATA_DIR / target_rel_path)
+
+            self.run_ingestion(
+                force=False, progress_callback=progress_callback, target_files=target_paths
+            )
 
 
 # 하위 호환성을 위한 기존 클래스 래핑

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -321,7 +321,7 @@ class IngestionPipeline:
         self,
         source_ids_to_delete: list[str] | None = None,
         relative_paths_to_delete: list[str] | None = None,
-        filenames_to_delete: list[str] | None = None
+        filenames_to_delete: list[str] | None = None,
     ):
         """
         DB, 캐시 및 가공된 JSON 파일에서 삭제된 데이터를 제거합니다.

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -562,7 +562,7 @@ class PipelineOrchestrator:
 
         return files_to_process, source_ids_to_delete, new_manifest
 
-    def _process_changes(
+    def _process_changes(  # noqa: C901
         self,
         files_to_process: list[Path],
         source_ids_to_delete: list[str],

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -160,9 +160,15 @@ class IngestionPipeline:
             files.extend(filtered_files)
         return files
 
-    def process_and_chunk(self, files: list[Path]) -> list[dict[str, Any]]:
+    def process_and_chunk(self, files: list[Path], progress_callback=None) -> list[dict[str, Any]]:
         all_hierarchical_data = []
-        for file_path in tqdm(files, desc="Processing Files"):
+        total_files = len(files)
+        for idx, file_path in enumerate(files):
+            if progress_callback:
+                try:
+                    progress_callback(idx, total_files, file_path.name)
+                except Exception as cb_e:
+                    logger.error(f"진행 상황 콜백 호출 실패: {cb_e}")
             try:
                 # 1. 파일 확장자에 따른 전략 동적 선택 및 파싱
                 active_strategy = self.strategy if file_path.suffix.lower() == ".pdf" else MarkdownParserStrategy()
@@ -214,6 +220,12 @@ class IngestionPipeline:
 
             except Exception as e:
                 logger.error(f"파일 처리 실패: {file_path.name} - {e!s}")
+
+        if progress_callback and total_files > 0:
+            try:
+                progress_callback(total_files, total_files, "모든 파일 처리 완료")
+            except Exception as cb_e:
+                logger.error(f"진행 상황 콜백 호출 실패: {cb_e}")
 
         return all_hierarchical_data
 
@@ -372,7 +384,13 @@ class PipelineOrchestrator:
 
         return files_to_process, source_ids_to_delete, new_manifest
 
-    def _process_changes(self, files_to_process: list[Path], source_ids_to_delete: list[str], session: Any):
+    def _process_changes(
+        self,
+        files_to_process: list[Path],
+        source_ids_to_delete: list[str],
+        session: Any,
+        progress_callback=None,
+    ):
         """도출된 변경 사항(DB 삭제, 파싱, 업서트, 인덱스 갱신)을 순차적으로 수행합니다."""
         if files_to_process or source_ids_to_delete:
             with session.trace_step("cache_flush"):
@@ -385,7 +403,9 @@ class PipelineOrchestrator:
 
         if files_to_process:
             with session.trace_step("parse_and_chunk") as step:
-                processed_data = self.ingestion_pipeline.process_and_chunk(files_to_process)
+                processed_data = self.ingestion_pipeline.process_and_chunk(
+                    files_to_process, progress_callback=progress_callback
+                )
                 step["parent_chunk_count"] = len(processed_data)
 
             if processed_data:
@@ -406,8 +426,16 @@ class PipelineOrchestrator:
                 except Exception as e:
                     step["status"] = f"failed: {e}"
 
-    def run_ingestion(self, force: bool = False):
+    def run_ingestion(self, force: bool = False, parser_type: str = None, progress_callback=None):
         """전체 데이터 구축 파이프라인 실행"""
+        if parser_type:
+            parser_type_lower = parser_type.lower()
+            if self.parser_type != parser_type_lower:
+                logger.info(f"파서 타입 변경 감지: {self.parser_type} -> {parser_type_lower}")
+                self.parser_type = parser_type_lower
+                self.strategy = self._get_parser_strategy()
+                self.ingestion_pipeline.strategy = self.strategy
+
         logger.info(f"데이터 구축 파이프라인을 시작합니다. (전략: {self.parser_type}, 강제 재색인: {force})")
 
         with self.tracing_logger.start_session(type="ingestion", parser_type=self.parser_type) as session:
@@ -468,7 +496,12 @@ class PipelineOrchestrator:
                         self._save_manifest(new_manifest)
                     return
 
-            self._process_changes(files_to_process, source_ids_to_delete, session)
+            self._process_changes(
+                files_to_process,
+                source_ids_to_delete,
+                session,
+                progress_callback=progress_callback,
+            )
 
             with session.trace_step("update_manifest"):
                 self._save_manifest(new_manifest)

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -172,8 +172,22 @@ class IngestionPipeline:
             try:
                 # 1. 파일 확장자에 따른 전략 동적 선택 및 파싱
                 if file_path.suffix.lower() == ".pdf":
-                    rel_path = str(file_path.relative_to(RAW_DATA_DIR))
-                    file_parser = (file_parser_types or {}).get(rel_path, "manual").lower()
+                    import unicodedata
+
+                    rel_path = unicodedata.normalize("NFC", str(file_path.relative_to(RAW_DATA_DIR)))
+                    normalized_parser_types = {
+                        unicodedata.normalize("NFC", k): v for k, v in (file_parser_types or {}).items()
+                    }
+                    file_parser = normalized_parser_types.get(rel_path, "manual").lower()
+                    logger.warning(
+                        f"=== 디버깅 파서 선택 ===\n"
+                        f"파일명: {file_path.name}\n"
+                        f"rel_path (NFC): {rel_path}\n"
+                        f"결정된 file_parser: {file_parser}\n"
+                        f"전달된 file_parser_types: {file_parser_types}\n"
+                        f"정규화된 parser_types: {normalized_parser_types}\n"
+                        f"========================="
+                    )
                     if file_parser == "docling":
                         try:
                             import docling  # noqa: F401
@@ -266,37 +280,90 @@ class IngestionPipeline:
 
         return saved_paths
 
-    def cleanup_db(self, source_ids_to_delete: list[str]):
+    def _prepare_cleanup_targets(
+        self, source_ids_to_delete: list[str] | None, filenames_to_delete: list[str] | None
+    ) -> tuple[list[str], list[str]]:
+        import unicodedata
+        from pathlib import Path
+
+        valid_ids = list(set([sid for sid in (source_ids_to_delete or []) if sid]))
+
+        target_filenames = []
+        if filenames_to_delete:
+            for fname in filenames_to_delete:
+                if not fname:
+                    continue
+                name_only = Path(fname).name
+                nfc_n = unicodedata.normalize("NFC", name_only)
+                nfd_n = unicodedata.normalize("NFD", name_only)
+                target_filenames.extend([nfc_n, nfd_n])
+
+        target_filenames = list(set(target_filenames))
+
+        if target_filenames:
+            logger.info(f"파일명 기반 클린업 대상 확인: {filenames_to_delete}")
+            try:
+                results = self.db_manager.collection.get(
+                    where={"src_name": {"$in": target_filenames}}, include=["metadatas"]
+                )
+                if results and results.get("metadatas"):
+                    for meta in results["metadatas"]:
+                        if meta and "source_id" in meta:
+                            valid_ids.append(meta["source_id"])
+            except Exception as e:
+                logger.error(f"파일명 기반 source_id 조회 중 오류 발생: {e}")
+
+        return list(set(valid_ids)), target_filenames
+
+    def _cleanup_local_files(self, valid_ids: list[str]) -> int:
+        deleted_count = 0
+        for sid in valid_ids:
+            cache_file = CACHE_DIR / f"{sid}_parsed.pkl"
+            if cache_file.exists():
+                try:
+                    cache_file.unlink()
+                except Exception as e:
+                    logger.error(f"캐시 파일 삭제 실패 {cache_file.name}: {e}")
+
+            json_file = self.processed_dir / f"{sid}.json"
+            if json_file.exists():
+                try:
+                    json_file.unlink()
+                    deleted_count += 1
+                except Exception as e:
+                    logger.error(f"JSON 파일 삭제 실패 {json_file.name}: {e}")
+        return deleted_count
+
+    def cleanup_db(self, source_ids_to_delete: list[str] | None = None, filenames_to_delete: list[str] | None = None):
         """
         DB, 캐시 및 가공된 JSON 파일에서 삭제된 데이터를 제거합니다.
         (BM25Manager는 processed_dir의 모든 json을 읽으므로 물리적 파일 삭제가 곧 정합성임)
         """
-        valid_ids = [sid for sid in source_ids_to_delete if sid]
-        if not valid_ids:
+        valid_ids, target_filenames = self._prepare_cleanup_targets(source_ids_to_delete, filenames_to_delete)
+
+        if not valid_ids and not target_filenames:
             return
 
-        logger.info(f"데이터 정합성 검증: {len(valid_ids)}개 소스 ID에 대한 클린업을 수행합니다.")
+        logger.info(
+            f"데이터 정합성 검증: {len(valid_ids)}개 소스 ID, "
+            f"{len(target_filenames)}개 파일명 조건에 대한 클린업을 수행합니다."
+        )
 
         # 1. 벡터 DB 데이터 삭제
-        self.db_manager.delete_documents(where={"source_id": {"$in": valid_ids}})
-        logger.info("   - ChromaDB 벡터 데이터 삭제 완료")
+        try:
+            if valid_ids:
+                self.db_manager.delete_documents(where={"source_id": {"$in": valid_ids}})
+            if target_filenames:
+                self.db_manager.delete_documents(where={"src_name": {"$in": target_filenames}})
+            logger.info("ChromaDB 벡터 데이터 삭제 완료")
+        except Exception as e:
+            logger.error(f"ChromaDB 벡터 데이터 삭제 실패: {e}")
 
         # 2. 물리적 캐시 및 JSON 파일 삭제 (강화된 클린업)
-        deleted_count = 0
-        for sid in valid_ids:
-            # 파싱 캐시 삭제
-            cache_file = CACHE_DIR / f"{sid}_parsed.pkl"
-            if cache_file.exists():
-                cache_file.unlink()
-
-            # 가공된 JSON 삭제 (BM25 정합성 핵심)
-            json_file = self.processed_dir / f"{sid}.json"
-            if json_file.exists():
-                json_file.unlink()
-                deleted_count += 1
+        deleted_count = self._cleanup_local_files(valid_ids)
 
         if deleted_count > 0:
-            logger.info(f"   - 물리적 데이터 파일 {deleted_count}개 삭제 완료")
+            logger.info(f"물리적 데이터 파일 {deleted_count}개 삭제 완료")
 
         logger.info("데이터 정합성 검증 및 클린업 작업이 완료되었습니다.")
 
@@ -404,8 +471,16 @@ class PipelineOrchestrator:
 
         new_files = {}
         for f in all_files:
-            rel_path = str(f.relative_to(RAW_DATA_DIR))
+            import unicodedata
+
+            rel_path = unicodedata.normalize("NFC", str(f.relative_to(RAW_DATA_DIR)))
             old_info = old_files.get(rel_path, {})
+            if not old_info:
+                # NFD-NFC 매치 백업
+                for k, v in old_files.items():
+                    if unicodedata.normalize("NFC", k) == rel_path:
+                        old_info = v
+                        break
             file_parser_type = old_info.get("parser_type", self.parser_type)
             h = generate_file_hash(f, file_parser_type)
             new_files[rel_path] = {"hash": h, "parser_type": file_parser_type}
@@ -444,7 +519,19 @@ class PipelineOrchestrator:
 
         if source_ids_to_delete:
             with session.trace_step("db_cleanup"):
-                self.ingestion_pipeline.cleanup_db(source_ids_to_delete)
+                filenames_to_delete = []
+                try:
+                    old_manifest = self._load_manifest()
+                    old_files = old_manifest.get("files", {})
+                    for rel_path, info in old_files.items():
+                        if info.get("hash") in source_ids_to_delete:
+                            filenames_to_delete.append(Path(rel_path).name)
+                except Exception as e:
+                    logger.error(f"삭제 파일명 추출 중 오류 발생: {e}")
+
+                self.ingestion_pipeline.cleanup_db(
+                    source_ids_to_delete=source_ids_to_delete, filenames_to_delete=filenames_to_delete
+                )
 
         if files_to_process:
             with session.trace_step("parse_and_chunk") as step:
@@ -468,7 +555,7 @@ class PipelineOrchestrator:
                         progress_callback(
                             len(files_to_process),
                             len(files_to_process),
-                            "임베딩 변환 및 벡터 적재 중 (시간이 소요될 수 있습니다)"
+                            "임베딩 변환 및 벡터 적재 중 (시간이 소요될 수 있습니다)",
                         )
                     except Exception as cb_e:
                         logger.error(f"진행 상황 콜백 호출 실패: {cb_e}")
@@ -539,8 +626,10 @@ class PipelineOrchestrator:
                     source_ids_to_delete = []  # 이미 물리적으로 모두 삭제했으므로 부분 삭제 프로세스는 건너뜀
 
                     new_files = {}
+                    import unicodedata
+
                     for f in all_files:
-                        rel_path = str(f.relative_to(RAW_DATA_DIR))
+                        rel_path = unicodedata.normalize("NFC", str(f.relative_to(RAW_DATA_DIR)))
                         new_files[rel_path] = {
                             "hash": generate_file_hash(f, self.parser_type),
                             "parser_type": self.parser_type,
@@ -554,9 +643,7 @@ class PipelineOrchestrator:
                 # target_files 부분 동기화 필터링 적용
                 if target_files is not None:
                     target_paths = {p.resolve() for p in target_files}
-                    filtered_files_to_process = [
-                        f for f in files_to_process if f.resolve() in target_paths
-                    ]
+                    filtered_files_to_process = [f for f in files_to_process if f.resolve() in target_paths]
 
                     # target_files에 해당하지 않는 문서들의 구 해시값은 delete 목록에서 보존
                     target_names = {p.name for p in target_files}
@@ -620,16 +707,24 @@ class PipelineOrchestrator:
         old_manifest = self._load_manifest()
         old_files = old_manifest.get("files", {})
 
+        import unicodedata
+
+        normalized_file_name = unicodedata.normalize("NFC", file_name)
         target_rel_path = None
         for rel_path in old_files:
-            if Path(rel_path).name == file_name or rel_path == file_name:
+            normalized_rel_path = unicodedata.normalize("NFC", rel_path)
+            is_match = (
+                Path(normalized_rel_path).name == normalized_file_name or normalized_rel_path == normalized_file_name
+            )
+            if is_match:
                 target_rel_path = rel_path
                 break
 
         if not target_rel_path:
             for f in self.ingestion_pipeline.scan_files():
-                if f.name == file_name:
-                    target_rel_path = str(f.relative_to(RAW_DATA_DIR))
+                normalized_f_name = unicodedata.normalize("NFC", f.name)
+                if normalized_f_name == normalized_file_name:
+                    target_rel_path = unicodedata.normalize("NFC", str(f.relative_to(RAW_DATA_DIR)))
                     break
 
         if not target_rel_path:
@@ -640,6 +735,10 @@ class PipelineOrchestrator:
 
         if target_rel_path not in old_files:
             old_files[target_rel_path] = {}
+        old_hash = old_files[target_rel_path].get("hash")
+        hashes_to_delete = [old_hash] if old_hash else []
+        logger.info(f"파서 변경 전 기존 ChromaDB 데이터 클린업 수행 (파일명: {file_name}, 해시: {hashes_to_delete})")
+        self.ingestion_pipeline.cleanup_db(source_ids_to_delete=hashes_to_delete, filenames_to_delete=[file_name])
         old_files[target_rel_path]["hash"] = ""
         old_files[target_rel_path]["parser_type"] = new_parser_lower
 
@@ -648,9 +747,7 @@ class PipelineOrchestrator:
 
         # target_files를 전달하여 해당 파일만 동기화하도록 강제
         target_path = RAW_DATA_DIR / target_rel_path
-        self.run_ingestion(
-            force=False, progress_callback=progress_callback, target_files=[target_path]
-        )
+        self.run_ingestion(force=False, progress_callback=progress_callback, target_files=[target_path])
 
     def update_multiple_file_parsers(self, file_parser_map: dict[str, str], progress_callback=None):  # noqa: C901
         """복수 파일의 동기화 파서 타입을 한꺼번에 변경하고, 대상 파일들을 즉각 재색인합니다."""
@@ -658,28 +755,48 @@ class PipelineOrchestrator:
         old_files = old_manifest.get("files", {})
 
         updated_count = 0
+        hashes_to_delete = []
         for file_name, new_parser in file_parser_map.items():
             new_parser_lower = new_parser.lower()
+            import unicodedata
+
+            normalized_file_name = unicodedata.normalize("NFC", file_name)
 
             target_rel_path = None
             for rel_path in old_files:
-                if Path(rel_path).name == file_name or rel_path == file_name:
+                normalized_rel_path = unicodedata.normalize("NFC", rel_path)
+                is_match = (
+                    Path(normalized_rel_path).name == normalized_file_name
+                    or normalized_rel_path == normalized_file_name
+                )
+                if is_match:
                     target_rel_path = rel_path
                     break
 
             if not target_rel_path:
                 for f in self.ingestion_pipeline.scan_files():
-                    if f.name == file_name:
-                        target_rel_path = str(f.relative_to(RAW_DATA_DIR))
+                    normalized_f_name = unicodedata.normalize("NFC", f.name)
+                    if normalized_f_name == normalized_file_name:
+                        target_rel_path = unicodedata.normalize("NFC", str(f.relative_to(RAW_DATA_DIR)))
                         break
 
             if target_rel_path:
                 logger.info(f"파일 {target_rel_path}의 파서를 {new_parser_lower}로 변경 등록합니다.")
                 if target_rel_path not in old_files:
                     old_files[target_rel_path] = {}
+                old_hash = old_files[target_rel_path].get("hash")
+                if old_hash:
+                    hashes_to_delete.append(old_hash)
                 old_files[target_rel_path]["hash"] = ""
                 old_files[target_rel_path]["parser_type"] = new_parser_lower
                 updated_count += 1
+
+        if hashes_to_delete:
+            filenames_to_delete = list(file_parser_map.keys())
+            logger.info(f"파서 일괄 변경 전 기존 ChromaDB 데이터 클린업 수행 (개수: {len(filenames_to_delete)})")
+            self.ingestion_pipeline.cleanup_db(
+                source_ids_to_delete=hashes_to_delete, filenames_to_delete=filenames_to_delete
+            )
 
         if updated_count > 0:
             old_manifest["files"] = old_files
@@ -701,9 +818,7 @@ class PipelineOrchestrator:
                 if target_rel_path:
                     target_paths.append(RAW_DATA_DIR / target_rel_path)
 
-            self.run_ingestion(
-                force=False, progress_callback=progress_callback, target_files=target_paths
-            )
+            self.run_ingestion(force=False, progress_callback=progress_callback, target_files=target_paths)
 
 
 # 하위 호환성을 위한 기존 클래스 래핑

--- a/src/processing/chunking.py
+++ b/src/processing/chunking.py
@@ -180,6 +180,7 @@ class HierarchicalChunker:
                 MetadataFields.PARENT_ID: parent_id,
                 MetadataFields.HEADER_PATH: base_metadata.get(MetadataFields.HEADER_PATH, "기본 섹션"),
                 MetadataFields.IS_TABLE: has_table,
+                "parser": base_metadata.get("parser", "manual"),
             }
 
             children_list.append(
@@ -233,6 +234,7 @@ class HierarchicalChunker:
                     MetadataFields.CHUNK_ID: parent_id,
                     MetadataFields.PARENT_ID: None,
                     MetadataFields.HEADER_PATH: header_path,
+                    "parser": base_metadata.get("parser", "manual"),
                 }
 
                 hierarchical_data.append(

--- a/src/processing/chunking.py
+++ b/src/processing/chunking.py
@@ -180,7 +180,7 @@ class HierarchicalChunker:
                 MetadataFields.PARENT_ID: parent_id,
                 MetadataFields.HEADER_PATH: base_metadata.get(MetadataFields.HEADER_PATH, "기본 섹션"),
                 MetadataFields.IS_TABLE: has_table,
-                "parser": base_metadata.get("parser", "manual"),
+                MetadataFields.PARSER: base_metadata.get(MetadataFields.PARSER, "manual"),
             }
 
             children_list.append(
@@ -234,7 +234,7 @@ class HierarchicalChunker:
                     MetadataFields.CHUNK_ID: parent_id,
                     MetadataFields.PARENT_ID: None,
                     MetadataFields.HEADER_PATH: header_path,
-                    "parser": base_metadata.get("parser", "manual"),
+                    MetadataFields.PARSER: base_metadata.get(MetadataFields.PARSER, "manual"),
                 }
 
                 hierarchical_data.append(

--- a/src/tests/unit/test_parser_selection.py
+++ b/src/tests/unit/test_parser_selection.py
@@ -1,5 +1,4 @@
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
@@ -51,15 +50,21 @@ class TestParserSelection:
 
     def test_progress_callback_execution(self, orchestrator):
         """동기화 파이프라인 가동 시 progress_callback이 정상적으로 호출되는지 검증합니다."""
+        from src.utils.paths import RAW_DATA_DIR
+
         orchestrator.ingestion_pipeline = MagicMock()
 
-        # 3개의 모의 파일 스캔 결과
-        mock_files = [Path("file1.pdf"), Path("file2.pdf"), Path("file3.pdf")]
+        # 절대 경로로 모킹 파일 제공
+        mock_files = [RAW_DATA_DIR / "file1.pdf", RAW_DATA_DIR / "file2.pdf", RAW_DATA_DIR / "file3.pdf"]
         orchestrator.ingestion_pipeline.scan_files.return_value = mock_files
 
-        # manifest와 delta 계산 모킹하여 3개 파일 모두 변경된 것으로 설정
-        orchestrator._load_manifest = MagicMock(return_value={})
-        orchestrator._calculate_delta = MagicMock(return_value=(mock_files, [], {}))
+        # manifest와 delta 계산 모킹
+        orchestrator._load_manifest = MagicMock(
+            return_value={"version": "2.0", "global_parser_type": "manual", "files": {}}
+        )
+        orchestrator._calculate_delta = MagicMock(
+            return_value=(mock_files, [], {"version": "2.0", "global_parser_type": "manual", "files": {}})
+        )
 
         callback_calls = []
 
@@ -67,7 +72,7 @@ class TestParserSelection:
             callback_calls.append((current, total, file_name))
 
         # process_and_chunk가 호출될 때 콜백을 직접 구동하도록 모의 구현
-        def mock_process_and_chunk(files, progress_callback=None):
+        def mock_process_and_chunk(files, progress_callback=None, file_parser_types=None):
             for idx, f in enumerate(files):
                 if progress_callback:
                     progress_callback(idx, len(files), f.name)
@@ -83,9 +88,123 @@ class TestParserSelection:
         orchestrator.run_ingestion(parser_type="manual", progress_callback=dummy_callback)
 
         # callback_calls에 기록된 호출 횟수 및 인자 검증
-        # 3개 파일에 대해 파일 단위 호출 + 최종 완료 호출 = 4번 호출되어야 함
         assert len(callback_calls) == 4
         assert callback_calls[0] == (0, 3, "file1.pdf")
         assert callback_calls[1] == (1, 3, "file2.pdf")
         assert callback_calls[2] == (2, 3, "file3.pdf")
         assert callback_calls[3] == (3, 3, "완료")
+
+    def test_manifest_backward_compatibility(self, orchestrator):
+        """이전 규격(1.0)의 매니페스트를 로드할 때 2.0 포맷으로 자동 래핑 변환하는지 검증합니다."""
+        mock_data = {"rules.pdf": "hash123", "info.md": "hash456"}
+        import json
+
+        mock_json = json.dumps(mock_data)
+
+        with patch("pathlib.Path.exists", return_value=True), patch("builtins.open", mock_open(read_data=mock_json)):
+            loaded = orchestrator._load_manifest()
+
+            # 검증: 2.0 구조로 자동 래핑 전환 여부
+            assert loaded["version"] == "2.0"
+            assert loaded["global_parser_type"] == "manual"
+            assert "rules.pdf" in loaded["files"]
+            assert loaded["files"]["rules.pdf"]["hash"] == "hash123"
+            assert loaded["files"]["rules.pdf"]["parser_type"] == "manual"
+
+    def test_calculate_delta_with_per_file_parser(self, orchestrator):
+        """각 파일별로 다른 파서 타입이 지정되어 있을 때,
+        해당 파서 규칙에 따라 개별적으로 델타 해시가 연산되는지 검증합니다.
+        """
+        from src.utils.paths import RAW_DATA_DIR
+
+        mock_files = [RAW_DATA_DIR / "rules.pdf", RAW_DATA_DIR / "info.md"]
+
+        # 2.0 규격 매니페스트
+        old_manifest = {
+            "version": "2.0",
+            "global_parser_type": "manual",
+            "files": {
+                "rules.pdf": {"hash": "old_rules_hash", "parser_type": "docling"},
+                "info.md": {"hash": "old_info_hash", "parser_type": "manual"},
+            },
+        }
+
+        # generate_file_hash 함수가 호출될 때, 각 파서 타입이 의도대로 넘어가는지 모킹
+        with patch("src.pipeline.generate_file_hash") as mock_hash_gen:
+            mock_hash_gen.side_effect = lambda f, parser_type: f"hash_of_{f.name}_by_{parser_type}"
+
+            _, _, new_manifest = orchestrator._calculate_delta(mock_files, old_manifest)
+
+            # rules.pdf는 docling 기준, info.md는 manual 기준으로 해시가 호출되었는지 검증
+            mock_hash_gen.assert_any_call(RAW_DATA_DIR / "rules.pdf", "docling")
+            mock_hash_gen.assert_any_call(RAW_DATA_DIR / "info.md", "manual")
+
+            # 생성된 new_manifest 값 검증
+            files = new_manifest["files"]
+            assert files["rules.pdf"]["hash"] == "hash_of_rules.pdf_by_docling"
+            assert files["rules.pdf"]["parser_type"] == "docling"
+            assert files["info.md"]["hash"] == "hash_of_info.md_by_manual"
+            assert files["info.md"]["parser_type"] == "manual"
+
+    def test_update_file_parser_execution(self, orchestrator):
+        """특정 파일의 파서 변경 함수 호출 시, 매니페스트에 정상 반영되고 인덱싱이 기동되는지 검증합니다."""
+        old_manifest = {
+            "version": "2.0",
+            "global_parser_type": "manual",
+            "files": {"rules.pdf": {"hash": "hash_val", "parser_type": "manual"}},
+        }
+
+        orchestrator._load_manifest = MagicMock(return_value=old_manifest)
+        orchestrator._save_manifest = MagicMock()
+        orchestrator.run_ingestion = MagicMock()
+
+        # rules.pdf의 파서를 docling으로 변경 실행
+        orchestrator.update_file_parser("rules.pdf", "docling")
+
+        # 매니페스트 갱신 저장 확인
+        orchestrator._save_manifest.assert_called_once()
+        saved_manifest = orchestrator._save_manifest.call_args[0][0]
+        assert saved_manifest["files"]["rules.pdf"]["parser_type"] == "docling"
+
+        # 동기화 프로세스 실행 확인 (target_files 리스트 전달 검증)
+        orchestrator.run_ingestion.assert_called_once()
+        call_kwargs = orchestrator.run_ingestion.call_args[1]
+        assert call_kwargs["force"] is False
+        assert call_kwargs["progress_callback"] is None
+        assert len(call_kwargs["target_files"]) == 1
+        assert call_kwargs["target_files"][0].name == "rules.pdf"
+
+    def test_update_multiple_file_parsers_execution(self, orchestrator):
+        """복수 파일의 파서 변경 함수 호출 시, 매니페스트에 일괄 반영되고 인덱싱이 기동되는지 검증합니다."""
+        old_manifest = {
+            "version": "2.0",
+            "global_parser_type": "manual",
+            "files": {
+                "rules.pdf": {"hash": "hash1", "parser_type": "manual"},
+                "info.md": {"hash": "hash2", "parser_type": "manual"},
+            },
+        }
+
+        orchestrator._load_manifest = MagicMock(return_value=old_manifest)
+        orchestrator._save_manifest = MagicMock()
+        orchestrator.run_ingestion = MagicMock()
+
+        # rules.pdf와 info.md를 모두 docling으로 변경 실행
+        orchestrator.update_multiple_file_parsers({
+            "rules.pdf": "docling",
+            "info.md": "docling"
+        })
+
+        # 매니페스트 갱신 저장 확인
+        orchestrator._save_manifest.assert_called_once()
+        saved_manifest = orchestrator._save_manifest.call_args[0][0]
+        assert saved_manifest["files"]["rules.pdf"]["parser_type"] == "docling"
+        assert saved_manifest["files"]["info.md"]["parser_type"] == "docling"
+
+        # 동기화 프로세스 실행 확인 (target_files 리스트 전달 검증)
+        orchestrator.run_ingestion.assert_called_once()
+        call_kwargs = orchestrator.run_ingestion.call_args[1]
+        assert call_kwargs["force"] is False
+        assert call_kwargs["progress_callback"] is None
+        assert len(call_kwargs["target_files"]) == 2
+        assert {p.name for p in call_kwargs["target_files"]} == {"rules.pdf", "info.md"}

--- a/src/tests/unit/test_parser_selection.py
+++ b/src/tests/unit/test_parser_selection.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.pipeline import PipelineOrchestrator
+
+
+class TestParserSelection:
+    @pytest.fixture
+    def orchestrator(self):
+        """PipelineOrchestrator 싱글톤을 초기화하고 테스트를 위한 모의 객체들을 연동합니다."""
+        # 싱글톤 인스턴스 초기화 우회 또는 재설정을 위해 _instance를 None으로 강제 설정
+        PipelineOrchestrator._instance = None
+
+        with (
+            patch("src.pipeline.ChromaDBManager") as mock_chroma_class,
+            patch("src.pipeline.SemanticCache") as mock_cache_class,
+            patch("src.pipeline.settings") as mock_settings,
+        ):
+            mock_chroma_class.return_value = MagicMock()
+            mock_cache_class.return_value = MagicMock()
+            mock_settings.PARSER_TYPE = "manual"
+
+            orchestrator = PipelineOrchestrator()
+            yield orchestrator
+
+    def test_parser_type_dynamic_switch(self, orchestrator):
+        """run_ingestion 호출 시 parser_type 파라미터에 따라 파서 전략이 동적으로 전환되는지 검증합니다."""
+        # 초기 상태 확인 (기본값 settings.PARSER_TYPE = "manual"로 로드됨)
+        assert orchestrator.parser_type == "manual"
+
+        # 헬퍼 및 서브 모듈 모킹
+        orchestrator.ingestion_pipeline = MagicMock()
+        orchestrator.ingestion_pipeline.scan_files.return_value = []
+        orchestrator._load_manifest = MagicMock(return_value={})
+
+        # docling 라이브러리가 로드되는 상황을 모킹하기 위해 patch 사용
+        with patch("src.pipeline.DoclingPDFParserStrategy") as mock_docling_strategy:
+            mock_docling_strategy.return_value = MagicMock()
+
+            # docling으로 전환 호출
+            with patch(
+                "builtins.__import__",
+                side_effect=lambda name, *args, **kwargs: MagicMock() if name == "docling" else None,
+            ):
+                orchestrator.run_ingestion(parser_type="docling")
+
+                # 검증
+                assert orchestrator.parser_type == "docling"
+
+    def test_progress_callback_execution(self, orchestrator):
+        """동기화 파이프라인 가동 시 progress_callback이 정상적으로 호출되는지 검증합니다."""
+        orchestrator.ingestion_pipeline = MagicMock()
+
+        # 3개의 모의 파일 스캔 결과
+        mock_files = [Path("file1.pdf"), Path("file2.pdf"), Path("file3.pdf")]
+        orchestrator.ingestion_pipeline.scan_files.return_value = mock_files
+
+        # manifest와 delta 계산 모킹하여 3개 파일 모두 변경된 것으로 설정
+        orchestrator._load_manifest = MagicMock(return_value={})
+        orchestrator._calculate_delta = MagicMock(return_value=(mock_files, [], {}))
+
+        callback_calls = []
+
+        def dummy_callback(current, total, file_name):
+            callback_calls.append((current, total, file_name))
+
+        # process_and_chunk가 호출될 때 콜백을 직접 구동하도록 모의 구현
+        def mock_process_and_chunk(files, progress_callback=None):
+            for idx, f in enumerate(files):
+                if progress_callback:
+                    progress_callback(idx, len(files), f.name)
+            if progress_callback:
+                progress_callback(len(files), len(files), "완료")
+            return []
+
+        orchestrator.ingestion_pipeline.process_and_chunk = mock_process_and_chunk
+        orchestrator.ingestion_pipeline.save_processed_data = MagicMock(return_value=[])
+        orchestrator.ingestion_pipeline.upsert_to_db = MagicMock()
+
+        # 실행
+        orchestrator.run_ingestion(parser_type="manual", progress_callback=dummy_callback)
+
+        # callback_calls에 기록된 호출 횟수 및 인자 검증
+        # 3개 파일에 대해 파일 단위 호출 + 최종 완료 호출 = 4번 호출되어야 함
+        assert len(callback_calls) == 4
+        assert callback_calls[0] == (0, 3, "file1.pdf")
+        assert callback_calls[1] == (1, 3, "file2.pdf")
+        assert callback_calls[2] == (2, 3, "file3.pdf")
+        assert callback_calls[3] == (3, 3, "완료")

--- a/src/tests/unit/test_parser_selection.py
+++ b/src/tests/unit/test_parser_selection.py
@@ -190,10 +190,7 @@ class TestParserSelection:
         orchestrator.run_ingestion = MagicMock()
 
         # rules.pdf와 info.md를 모두 docling으로 변경 실행
-        orchestrator.update_multiple_file_parsers({
-            "rules.pdf": "docling",
-            "info.md": "docling"
-        })
+        orchestrator.update_multiple_file_parsers({"rules.pdf": "docling", "info.md": "docling"})
 
         # 매니페스트 갱신 저장 확인
         orchestrator._save_manifest.assert_called_once()

--- a/src/vector_db/bm25_manager.py
+++ b/src/vector_db/bm25_manager.py
@@ -30,8 +30,12 @@ class BM25Manager:
         self.bm25 = None
         self.corpus_data = []
 
-        # 중앙 관리되는 캐시 파일 경로 사용
-        self.cache_path = BM25_CACHE_FILE
+        # data_dir이 기본 PROCESSED_DATA_DIR인 경우 BM25_CACHE_FILE을 사용하고,
+        # 그렇지 않으면 data_dir 하위에 캐시 파일을 생성하여 테스트 환경과 분리함
+        if data_dir == PROCESSED_DATA_DIR:
+            self.cache_path = BM25_CACHE_FILE
+        else:
+            self.cache_path = data_dir / "bm25_cache.pkl"
 
         # 동의어 사전 로드
         self.synonyms = self._load_synonyms()

--- a/src/vector_db/chroma_manager.py
+++ b/src/vector_db/chroma_manager.py
@@ -221,6 +221,28 @@ class ChromaDBManager:
                 logger.error(f"소스별 카운트 조회 중 오류 발생 ({source_name}): {e}")
                 return 0
 
+    def get_source_chunks(self, source_name: str) -> list[dict[str, Any]]:
+        """특정 소스 파일명(metadata.src_name)에 해당하는 청크 텍스트와 메타데이터 목록을 반환합니다."""
+        try:
+            results = self.collection.get(
+                where={MetadataFields.SRC_NAME: source_name},
+                include=["documents", "metadatas"],
+            )
+            chunks = []
+            if results and "ids" in results:
+                for i in range(len(results["ids"])):
+                    chunks.append(
+                        {
+                            "id": results["ids"][i],
+                            "content": results["documents"][i] if results["documents"] else "",
+                            "metadata": results["metadatas"][i] if results["metadatas"] else {},
+                        }
+                    )
+            return chunks
+        except Exception as e:
+            logger.error(f"소스별 청크 데이터 조회 중 오류 발생 ({source_name}): {e}")
+            return []
+
     def delete_documents(self, where: dict[str, Any]):
         """
         조건(where)에 맞는 도큐먼트들을 컬렉션에서 삭제합니다.

--- a/src/vector_db/chroma_manager.py
+++ b/src/vector_db/chroma_manager.py
@@ -190,9 +190,13 @@ class ChromaDBManager:
 
     def get_source_count(self, source_name: str) -> int:
         """특정 소스 파일명(metadata.src_name)에 해당하는 청크 수를 반환합니다."""
+        import unicodedata
+
+        nfc_name = unicodedata.normalize("NFC", source_name)
+        nfd_name = unicodedata.normalize("NFD", source_name)
         try:
             results = self.collection.get(
-                where={MetadataFields.SRC_NAME: source_name},
+                where={MetadataFields.SRC_NAME: {"$in": [nfc_name, nfd_name]}},
                 include=[],  # 실제 데이터는 필요 없으므로 빈 리스트
             )
             return len(results["ids"])
@@ -210,7 +214,7 @@ class ChromaDBManager:
                         metadata={"hnsw:space": "cosine"},
                     )
                     results = self.collection.get(
-                        where={MetadataFields.SRC_NAME: source_name},
+                        where={MetadataFields.SRC_NAME: {"$in": [nfc_name, nfd_name]}},
                         include=[],
                     )
                     return len(results["ids"])
@@ -223,9 +227,13 @@ class ChromaDBManager:
 
     def get_source_chunks(self, source_name: str) -> list[dict[str, Any]]:
         """특정 소스 파일명(metadata.src_name)에 해당하는 청크 텍스트와 메타데이터 목록을 반환합니다."""
+        import unicodedata
+
+        nfc_name = unicodedata.normalize("NFC", source_name)
+        nfd_name = unicodedata.normalize("NFD", source_name)
         try:
             results = self.collection.get(
-                where={MetadataFields.SRC_NAME: source_name},
+                where={MetadataFields.SRC_NAME: {"$in": [nfc_name, nfd_name]}},
                 include=["documents", "metadatas"],
             )
             chunks = []


### PR DESCRIPTION
## 변경 사항 (Checklist)
[x] 새로운 기능 추가 (feature)
[x] 버그 수정 (bug fix)
[x] 리팩토링 (refactor)
[ ] 환경 설정 (setup)
[ ] 문서 수정 (docs)

## 주요 작업 내용
- **미동기화 파일 파서 활성화 및 개별 동기화 버튼 추가 (src/app.py)**: 대기(미동기화) 파일의 파서 선택 셀렉트박스를 상시 활성화하고, 개별 파일 단위 즉시 동기화를 실행할 수 있는 동기화 버튼(🔄)을 테이블에 탑재하였습니다.
- **파서 변경 시 기존 ChromaDB 중복 청크 누적 방지 (src/pipeline.py)**: 파서를 변경할 때 매니페스트에서 해시를 소멸시키기 전, 기존에 등록되어 있던 구 해시(source_id)를 ChromaDB에서 선제 클린업(`cleanup_db`)한 뒤 색인을 갱신하도록 패치하여 동일한 파일의 중복 청크 축적 문제를 원천 해결하였습니다.
- **개별 파일 부분 동기화 필터 및 매니페스트 제어 (src/pipeline.py)**: `run_ingestion` 메서드에 `target_files` 파라미터를 추가하여 지정 파일만 선별 재파싱 및 재색인하도록 필터링을 구현하였습니다.
- **단일 통합 청크 뷰어 설계 및 페이징 고도화 (src/app.py)**: 탭 구분을 제거하고 하나의 다이얼로그 팝업 내에서 청크 목록을 들여다보는 단일 뷰를 구축하였습니다. 10개 단위 슬라이딩 윈도우 기반의 가로 숫자 페이지 네비게이션바 및 이전/다음 버튼을 이식하였습니다.
- **Mac OS 한글 자소 분리(NFD) 완벽 대응 (src/pipeline.py, src/app.py)**: Mac OS 환경에서 한글 파일명이 자소 분리(NFD)되어 매니페스트 룩업에 실패하고 전역 기본 파서로 폴백되는 문제를 해결하기 위해, 파일 스캔 경로, 매니페스트 딕셔너리 키 및 UI 룩업 파트 전반에 걸쳐 `unicodedata.normalize("NFC", ...)` 정규화를 관철하였습니다.
- **청크 상세 및 부모 문맥 렌더링 누락 문제 해결 (src/app.py)**: Streamlit 다이얼로그의 레이아웃 충돌로 인해 `st.text_area` 컴포넌트가 누락되거나 사라지던 버그를 완화하기 위해, 다크 모드 가독성을 개선하고 스크롤이 가능한 HTML/CSS 기반 `st.markdown` 박스로 교체하여 본문을 안정적으로 렌더링하였습니다.

## 기술적 도전 및 해결 과정 (Narrative)
- **파서 변경 시 기존 청크의 물리적 잔존 및 데이터 누적 문제 타개**: 파서를 강제 교체한 뒤 재색인을 수행할 때, 델타 계산 시점에서 기존 파일 해시가 이미 매니페스트상에서 빈 값(`""`)으로 초기화되어 있었기 때문에 파이프라인이 삭제할 '구 해시'를 찾지 못하고 기존 청크가 ChromaDB에 그대로 잔존해 데이터가 늘어나는 버그가 있었습니다. 이를 해결하기 위해 파서 변경 요청(`update_file_parser`) 시점에 매니페스트를 날리기 전, 기존에 맵핑되어 있던 해시를 백업하여 ChromaDB 데이터 클린업을 선행하도록 생명주기를 설계하였습니다.
- **Mac OS 한글 자소 분리 대응 및 Streamlit 렌더링 한계 극복**: Mac OS에서 생성된 PDF 등의 파일명은 유니코드 NFD 형식(자소 분리)을 띠고 있어, DB의 파일명과 매니페스트 해시 비교 매칭 시 한글 파일명이 불일치하여 해시 매핑에 실패하는 중대한 이슈가 있었습니다. 이를 해결하기 위해 NFC 정규화를 매칭 로직 전체에 관통 적용하여 한글 파일명 추적이 100% 성공하도록 보완하였습니다. 더불어 다이얼로그 팝업 내에서 Streamlit 네이티브 `st.text_area`가 간헐적으로 레이아웃 붕괴를 일으켜 텍스트 본문이 통째로 가려지는 문제를 HTML/CSS 오버플로우 스크롤 스타일의 마크다운 렌더링 방식으로 우회 해결하였습니다.

## 결과 증빙 및 검증 리포트

### 1. 임의 파서 선택 및 동기화 수행 결과 검증
* **검증 내용**: 대기 상태의 문서 파일(예: `조선대학교_학칙.pdf`)에 대해 적용 파서를 `manual`에서 `docling`으로 임의 변경하고 동기화(🔄) 버튼을 실행하였습니다.
* **확인 결과**: 파서 변경 및 동기화 완료 후 ChromaDB 및 매니페스트를 조회한 결과, 해당 파일의 청크 데이터와 메타데이터 필드 내의 `parser` 값이 `docling`으로 정상 반영 및 색인 갱신이 완료됨을 확인하였습니다.
* **추가 검증**: 파서를 변경하며 여러 번 동기화를 반복 수행하여도 기존에 존재하던 청크 데이터(`parser: manual`)가 선제적으로 확실히 제거되며, 중복 누적 현상 없이 설정 파서의 최신 청크들만 안전하게 남음을 입증하였습니다.

### 2. 동기화 진행률 및 실시간 단계 표시 검증
* **검증 내용**: 동기화 버튼을 클릭한 시점부터 동기화가 완료될 때까지의 UI 진행 피드백 동작을 확인하였습니다.
* **확인 결과**: Streamlit의 `st.status` 컴포넌트 하위에서 프로그레스 바(Progress Bar)가 실시간으로 채워지며, 현재 파싱 중인 파일 정보 및 단계별 상세 상황 메시지(예: `파일 파싱 중...`, `ChromaDB 색인 반영 중...`)가 화면상에 부드럽게 갱신 및 표시됨을 확인하였습니다.

### 3. 문서 목록 내 파일별 파서 방식 매칭 노출 검증
* **검증 내용**: 메인 화면의 문서 테이블 레이아웃에서 파일별 설정 파서가 정상적으로 맵핑되어 노출되는지 검증하였습니다.
* **확인 결과**: 각 행의 '적용 파서' 컬럼에서 전역 설정을 추종하거나 사용자가 개별적으로 지정한 파서 유형(manual/docling)이 꼬임 없이 동적으로 표시됨을 확인하였습니다.

### 4. 청크 보기 팝업 시연 검증
* **검증 내용**: 청크 돋보기 팝업 다이얼로그를 통해 쪼개진 원문 조각, 메타데이터 상세, 부모 문맥이 올바르게 출력되는지 확인하였습니다.
* **확인 결과**:
  * **자식 텍스트**: 다크 모드 테마에 어우러지는 둥근 모서리의 회색 배경 스크롤 박스 형태로 쪼개진 청크 원문이 누락 없이 안전하게 표출되었습니다.
  * **메타데이터 상세**: 기본적으로 접힌 상태(`st.expander`)의 JSON 뷰어 구조로 깔끔하게 렌더링되었습니다.
  * **상위 부모 문맥 (Parent Context)**: 가독성 확보를 위해 기본적으로 접힌 형태의 익스팬더 안에 원본 부모 텍스트가 배치되었으며, 정상적으로 텍스트 전체를 대조 확인할 수 있음을 입증하였습니다.

## 셀프 체크리스트
[x] develop 브랜치를 최신으로 반영(merge/rebase)했나요?
[x] 불필요한 주석이나 테스트용 print문은 제거했나요?
[x] 관련 이슈 번호를 연결했나요? (Closes #111)
[x] 기술적 도전 및 해결 과정(Narrative)을 서사 형식으로 작성했나요?
