### PR TITLE
fix: resolve Streamlit document dialog closing immediately (#121)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -269,8 +269,12 @@ def show_chunks_viewer_dialog(file_name, db_manager):  # noqa: C901
         st.rerun()
 
 
+def reset_doc_dialog():
+    st.session_state.dialog_doc_to_show = None
+
+
 # [문서 원문 보기]
-@st.dialog("문서 원문 보기")
+@st.dialog("문서 원문 보기", on_dismiss=reset_doc_dialog)
 def show_document_dialog(doc: dict):
     source = doc.get("metadata", {}).get(MetadataFields.SRC_NAME, "알 수 없음")
     page = doc.get("metadata", {}).get(MetadataFields.PG_NUM, "-")
@@ -282,9 +286,8 @@ def show_document_dialog(doc: dict):
     st.markdown(f"**관련도 점수:** {score:.4f}")
     st.text_area("원문 내용", content, height=300)
     if st.button("닫기"):
-        # Removed st.rerun() here. Dialog will close when dialog_doc_to_show is set to None
-        # and the main app reruns.
-        pass
+        reset_doc_dialog()
+        st.rerun()
 
 
 def reset_admin_active():
@@ -987,7 +990,6 @@ for msg_idx, msg in enumerate(st.session_state.messages):
 
 if st.session_state.dialog_doc_to_show:
     show_document_dialog(st.session_state.dialog_doc_to_show)
-    st.session_state.dialog_doc_to_show = None
 
 
 def on_chat_submit():


### PR DESCRIPTION
## 변경 사항 (Checklist)

  * [ ] 새로운 기능 추가 (feature)
  * [x] 버그 수정 (fix)
  * [ ] 리팩토링 (refactor)
  * [ ] 환경 설정 (setup)

## 주요 작업 내용

- **원문 팝업 닫힘 현상 해결**:
  - `st.session_state.dialog_doc_to_show` 상태가 버튼 클릭 후 같은 렌더링 턴 내에서 즉시 `None`으로 밀리던 문제를 해결했습니다.
  - `@st.dialog` 데코레이터에 `on_dismiss=reset_doc_dialog` 콜백을 주입하고, 메인 흐름에서의 성급한 상태 초기화를 제거하여 Streamlit 렌더링 생명주기 하에서 팝업창 상태 유지를 정상화했습니다.
  - 팝업창 내 [닫기] 버튼 클릭 또는 바깥 레이어 클릭 시에만 안전하게 `dialog_doc_to_show` 상태가 `None`으로 리셋되고 새로고침이 트리거되도록 수정했습니다.

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**:
  - RAG 결과물 하단의 출처(원문 보기)를 클릭하면 팝업(`st.dialog`)이 열리자마자 0.1초 만에 강제로 닫혀버리는 현상 발생.
* **원인 분석**:
  - 모니터링 시스템 제어용으로 도입된 지연 리런(`st.session_state.should_rerun_app = True`)으로 인해, 버튼 클릭 시 즉시 스크립트 실행이 중단되지 않고 아래의 `dialog_doc_to_show = None`까지 연달아 실행되었습니다.
  - 이로 인해 다음 턴 새로고침 시점에 팝업이 다시 렌더링되지 않고 즉시 폐기(Dismiss)되는 생명주기 모순 현상이 발생했습니다.
* **해결 방안**:
  - 팝업 수명(Life cycle)이 살아있는 동안 상태를 지속 보존하고, 명시적인 Dismiss 콜백(`reset_doc_dialog`)을 통해서만 자원이 회수되도록 설계를 고도화했습니다.

## 셀프 체크리스트

  * [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요?
  * [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
  * [x] 관련 이슈 번호를 연결했나요? (Resolves #121)
  * [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디

- 지연 리런 구조 하에서 `@st.dialog`를 가장 정석적이고 우아하게 다룰 수 있는 Dismiss 제어 패턴을 적용했습니다. 편하게 검토 부탁드립니다!
