### PR TITLE
feat: 보안 및 접근 제어 전체 고도화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,16 @@ DB_PATH=./vector_db
 # LANGCHAIN_TRACING_V2=true
 # LANGCHAIN_API_KEY=your_langchain_api_key_here
 # LANGCHAIN_PROJECT=context-rag-chatbot
+
+# 7. 보안 설정 (Issue 49/52/57)
+# APP_PASSWORD: 설정 시 앱 전체 접속 비밀번호 게이트 활성화
+# APP_PASSWORD=your_secure_app_password
+
+# ADMIN_PASSWORD: 관리자 패널 별도 비밀번호 (APP_PASSWORD와 다르게 설정 권장)
+# ADMIN_PASSWORD=your_secure_admin_password
+
+# SEMANTIC_CACHE_ENABLED: false 설정 시 멀티세션 캐시 공유 비활성화
+# SEMANTIC_CACHE_ENABLED=true
+
+# ⚠️ 주의: 이 파일을 절대 .git에 커밋하지 마세요.
+# .env 파일은 .gitignore에 포함되어야 합니다.

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,12 +59,18 @@ ENV PYTHONPATH=/app
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 
-# 소스 코드 및 관련 디렉토리 구조 생성
-RUN mkdir -p data/raw data/processed vector_db logs
+# Issue 53: non-root 사용자 생성으로 컨테이너 Root 권한 실행 취약점 제거
+RUN groupadd -r appgroup && useradd -r -g appgroup -u 1000 appuser
+
+# 소스 코드 및 관련 디렉토리 구조 생성 (appuser 소유)
+RUN mkdir -p data/raw data/processed vector_db logs && \
+    chown -R appuser:appgroup /app
 
 # 소스 코드 복사
-COPY src/ /app/src/
-COPY prompts/ /app/prompts/
+COPY --chown=appuser:appgroup src/ /app/src/
+COPY --chown=appuser:appgroup prompts/ /app/prompts/
+
+USER appuser
 
 # 포트 설정
 EXPOSE 8501

--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,19 @@ ensure_directories()
 # --- 2. 세션 상태 초기화 (중앙 이관 호출) ---
 init_session_state()
 
+# Issue 49: APP_PASSWORD 설정 시 앱 전체 인증 게이트
+if settings.APP_PASSWORD:
+    if not st.session_state.get("app_authenticated"):
+        st.title("🔒 RAG 챗봇")
+        pw = st.text_input("접속 비밀번호", type="password", key="app_pw")
+        if st.button("로그인"):
+            if pw == settings.APP_PASSWORD:
+                st.session_state.app_authenticated = True
+                st.rerun()
+            else:
+                st.error("비밀번호가 올바르지 않습니다.")
+        st.stop()
+
 
 def reset_doc_dialog():
     st.session_state.dialog_doc_to_show = None

--- a/src/app.py
+++ b/src/app.py
@@ -75,17 +75,16 @@ ensure_directories()
 init_session_state()
 
 # Issue 49: APP_PASSWORD 설정 시 앱 전체 인증 게이트
-if settings.APP_PASSWORD:
-    if not st.session_state.get("app_authenticated"):
-        st.title("🔒 RAG 챗봇")
-        pw = st.text_input("접속 비밀번호", type="password", key="app_pw")
-        if st.button("로그인"):
-            if pw == settings.APP_PASSWORD:
-                st.session_state.app_authenticated = True
-                st.rerun()
-            else:
-                st.error("비밀번호가 올바르지 않습니다.")
-        st.stop()
+if settings.APP_PASSWORD and not st.session_state.get("app_authenticated"):
+    st.title("🔒 RAG 챗봇")
+    pw = st.text_input("접속 비밀번호", type="password", key="app_pw")
+    if st.button("로그인"):
+        if pw == settings.APP_PASSWORD:
+            st.session_state.app_authenticated = True
+            st.rerun()
+        else:
+            st.error("비밀번호가 올바르지 않습니다.")
+    st.stop()
 
 
 def reset_doc_dialog():

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -44,10 +44,9 @@ class Settings(BaseSettings):
     RERANKER_MAX_DOCS: int = Field(default=5)
     RERANKER_BATCH_SIZE: int = Field(default=5)
     RERANKER_THRESHOLD: float = Field(default=0.5)
-    # 보안 설정 (Issue 51/57/44)
+    # 보안 설정 (Issue 51/57)
     SEMANTIC_CACHE_ENABLED: bool = Field(default=True)
     ADMIN_PASSWORD: str | None = Field(default=None)
-    LANGCHAIN_TRACING_V2: bool = Field(default=False)
 
     # 4. 파이프라인 및 파싱 설정
     PARSER_TYPE: Literal["manual", "docling"] = Field(default="docling")

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -44,7 +44,8 @@ class Settings(BaseSettings):
     RERANKER_MAX_DOCS: int = Field(default=5)
     RERANKER_BATCH_SIZE: int = Field(default=5)
     RERANKER_THRESHOLD: float = Field(default=0.5)
-    # 보안 설정 (Issue 51/57)
+    # 보안 설정 (Issue 49/51/57)
+    APP_PASSWORD: str | None = Field(default=None)
     SEMANTIC_CACHE_ENABLED: bool = Field(default=True)
     ADMIN_PASSWORD: str | None = Field(default=None)
 

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -44,6 +44,10 @@ class Settings(BaseSettings):
     RERANKER_MAX_DOCS: int = Field(default=5)
     RERANKER_BATCH_SIZE: int = Field(default=5)
     RERANKER_THRESHOLD: float = Field(default=0.5)
+    # 보안 설정 (Issue 51/57/44)
+    SEMANTIC_CACHE_ENABLED: bool = Field(default=True)
+    ADMIN_PASSWORD: str | None = Field(default=None)
+    LANGCHAIN_TRACING_V2: bool = Field(default=False)
 
     # 4. 파이프라인 및 파싱 설정
     PARSER_TYPE: Literal["manual", "docling"] = Field(default="docling")

--- a/src/core/cache.py
+++ b/src/core/cache.py
@@ -31,6 +31,9 @@ class SemanticCache:
         return self.collection
 
     def get(self, query_text: str) -> dict | None:
+        # Issue 51: 멀티세션 Data Bleed 방지 — SEMANTIC_CACHE_ENABLED=False로 비활성화 가능
+        if not settings.SEMANTIC_CACHE_ENABLED:
+            return None
         try:
             collection = self._get_valid_collection()
             query_embedding = self.db_manager.embed_query(query_text)
@@ -58,6 +61,8 @@ class SemanticCache:
         return None
 
     def add(self, query_text: str, answer: str, sources: list) -> None:
+        if not settings.SEMANTIC_CACHE_ENABLED:
+            return
         try:
             collection = self._get_valid_collection()
             sources_json = json.dumps(sources) if sources else ""

--- a/src/core/cache.py
+++ b/src/core/cache.py
@@ -10,8 +10,10 @@ logger = logging.getLogger(__name__)
 
 
 class SemanticCache:
-    def __init__(self):
-        self.collection_name = settings.SEMANTIC_CACHE_COLLECTION_NAME
+    def __init__(self, namespace: str | None = None):
+        # Issue 56: namespace(권한/역할)별 캐시 컬렉션 분리 — 권한 우회 방지
+        base_name = settings.SEMANTIC_CACHE_COLLECTION_NAME
+        self.collection_name = f"{base_name}_{namespace}" if namespace else base_name
         self.threshold = settings.SEMANTIC_CACHE_THRESHOLD
         self.db_manager = ChromaDBManager(collection_name=self.collection_name)
         self.collection = self.db_manager.collection

--- a/src/core/chains.py
+++ b/src/core/chains.py
@@ -170,7 +170,8 @@ class RAGPipeline:
                 role = msg.get("role")
                 content = msg.get("content", "")
                 if role == "user":
-                    messages.append(("human", content))
+                    # Issue 55: 멀티턴 대화 기록 프롬프트 인젝션 방어
+                    messages.append(("human", ContextBuilderNode.escape_injection(content)))
                 elif role == "assistant":
                     messages.append(("ai", content))
 

--- a/src/core/nodes.py
+++ b/src/core/nodes.py
@@ -35,14 +35,20 @@ class ContextBuilderNode:
         """문서 내 프롬프트 인젝션 유발 패턴을 이스케이프합니다."""
         return _INJECTION_PATTERN.sub(lambda m: f"[{m.group(0)}]", text)
 
+    @staticmethod
+    def escape_xml(text: str) -> str:
+        """Issue 54: XML 구조 탈출 방지 — 문서 내 < > & 이스케이핑."""
+        return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
     @classmethod
     def format_docs(cls, docs: list[Document]) -> str:
-        """프롬프트 주입 방어 XML 샌드박싱 적용 컨텍스트 포맷팅"""
+        """프롬프트 주입 방어 + XML 태그 이스케이핑 적용 컨텍스트 포맷팅"""
         formatted = []
         for i, doc in enumerate(docs, start=1):
             source = doc.metadata.get(MetadataFields.SRC_NAME) or "알 수 없는 파일"
             page = doc.metadata.get(MetadataFields.PG_NUM) or "-"
-            safe_content = cls.escape_injection(doc.page_content)
+            # 인젝션 패턴 → XML 태그 순으로 이스케이핑하여 샌드박스 탈출 차단
+            safe_content = cls.escape_xml(cls.escape_injection(doc.page_content))
             entry = f'<document index="{i}">\n내용: {safe_content}\n출처: [{source}, p.{page}]\n</document>'
             formatted.append(entry)
         return "\n\n".join(formatted)

--- a/src/ui/dialogs/admin.py
+++ b/src/ui/dialogs/admin.py
@@ -20,6 +20,19 @@ def reset_admin_active():
 
 @st.dialog("데이터 관리 시스템", width="large", on_dismiss=reset_admin_active)
 def show_admin_dialog(db_manager, initialize_rag_system_callback):  # noqa: C901
+    # Issue 57: ADMIN_PASSWORD 설정 시 관리자 인증 요구
+    if settings.ADMIN_PASSWORD:
+        if not st.session_state.get("admin_authenticated"):
+            st.subheader("관리자 인증")
+            pw = st.text_input("관리자 비밀번호", type="password", key="admin_pw_input")
+            if st.button("확인", key="admin_pw_confirm"):
+                if pw == settings.ADMIN_PASSWORD:
+                    st.session_state.admin_authenticated = True
+                    st.rerun()
+                else:
+                    st.error("비밀번호가 틀렸습니다.")
+            return
+
     st.markdown("지식 베이스(RAW_DATA) 관리 및 데이터베이스 동기화를 수행합니다.")
 
     # 상단 옵션 영역

--- a/src/ui/dialogs/admin.py
+++ b/src/ui/dialogs/admin.py
@@ -21,17 +21,16 @@ def reset_admin_active():
 @st.dialog("데이터 관리 시스템", width="large", on_dismiss=reset_admin_active)
 def show_admin_dialog(db_manager, initialize_rag_system_callback):  # noqa: C901
     # Issue 57: ADMIN_PASSWORD 설정 시 관리자 인증 요구
-    if settings.ADMIN_PASSWORD:
-        if not st.session_state.get("admin_authenticated"):
-            st.subheader("관리자 인증")
-            pw = st.text_input("관리자 비밀번호", type="password", key="admin_pw_input")
-            if st.button("확인", key="admin_pw_confirm"):
-                if pw == settings.ADMIN_PASSWORD:
-                    st.session_state.admin_authenticated = True
-                    st.rerun()
-                else:
-                    st.error("비밀번호가 틀렸습니다.")
-            return
+    if settings.ADMIN_PASSWORD and not st.session_state.get("admin_authenticated"):
+        st.subheader("관리자 인증")
+        pw = st.text_input("관리자 비밀번호", type="password", key="admin_pw_input")
+        if st.button("확인", key="admin_pw_confirm"):
+            if pw == settings.ADMIN_PASSWORD:
+                st.session_state.admin_authenticated = True
+                st.rerun()
+            else:
+                st.error("비밀번호가 틀렸습니다.")
+        return
 
     st.markdown("지식 베이스(RAW_DATA) 관리 및 데이터베이스 동기화를 수행합니다.")
 

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -14,4 +14,10 @@ module "ec2" {
   instance_type = var.instance_type
   project_name  = var.project_name
   key_name      = var.key_name
+
+  # Issue 45/47/48/50: 보안 강화 파라미터
+  allowed_cidr_blocks     = var.allowed_cidr_blocks
+  allowed_ssh_cidr_blocks = var.allowed_ssh_cidr_blocks
+  ssm_parameter_prefix    = "/rag-chatbot/dev"
+  vpc_cidr                = module.vpc.vpc_cidr
 }

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -21,3 +21,16 @@ variable "key_name" {
   type        = string
   default     = "rag-chatbot-key"
 }
+
+# Issue 45/47: 접근 IP 제한
+variable "allowed_cidr_blocks" {
+  description = "앱 UI 접속 허용 CIDR (예: [\"YOUR_IP/32\"])"
+  type        = list(string)
+  default     = []
+}
+
+variable "allowed_ssh_cidr_blocks" {
+  description = "SSH 허용 CIDR — 운영자 IP만 등록"
+  type        = list(string)
+  default     = []
+}

--- a/terraform/modules/ec2/main.tf
+++ b/terraform/modules/ec2/main.tf
@@ -1,20 +1,43 @@
+# Issue 45/47: 방화벽 취약 — SSH/앱 포트 0.0.0.0/0 전체 개방 제거
+# var.allowed_cidr_blocks 로 허용 IP 대역 제한 (기본값: 비어있어 접근 불가)
 resource "aws_security_group" "app_sg" {
   name        = "${var.project_name}-app-sg"
-  description = "Allow inbound traffic for RAG Chatbot"
+  description = "Allow inbound traffic for RAG Chatbot (restricted)"
   vpc_id      = var.vpc_id
 
+  # SSH: 운영팀 IP 대역만 허용
   ingress {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] # 보안을 위해 실제 환경에서는 특정 IP로 제한 필요
+    cidr_blocks = var.allowed_ssh_cidr_blocks
+    description = "SSH from approved admin IPs only"
   }
 
+  # Streamlit UI: 허용된 사용자 IP 대역만 접근
   ingress {
     from_port   = 8501
     to_port     = 8501
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] # 실제 운영 환경에서는 접속 허용 IP 대역 제한 권장
+    cidr_blocks = var.allowed_cidr_blocks
+    description = "Streamlit UI from approved IPs only"
+  }
+
+  # Issue 50: 백엔드 포트(ChromaDB 8000, Ollama 11434)는 내부 VPC 통신만 허용
+  ingress {
+    from_port   = 8000
+    to_port     = 8000
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+    description = "ChromaDB — VPC internal only"
+  }
+
+  ingress {
+    from_port   = 11434
+    to_port     = 11434
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+    description = "Ollama LLM — VPC internal only"
   }
 
   egress {
@@ -22,11 +45,45 @@ resource "aws_security_group" "app_sg" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound"
   }
 
   tags = {
     Name = "${var.project_name}-app-sg"
   }
+}
+
+# Issue 48: EC2 인스턴스 프로파일 — SSM 파라미터 읽기 권한
+resource "aws_iam_role" "app_role" {
+  name = "${var.project_name}-ec2-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "ssm_read" {
+  name = "${var.project_name}-ssm-read"
+  role = aws_iam_role.app_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["ssm:GetParameter", "ssm:GetParameters", "ssm:GetParametersByPath"]
+      Resource = "arn:aws:ssm:*:*:parameter${var.ssm_parameter_prefix}/*"
+    }]
+  })
+}
+
+resource "aws_iam_instance_profile" "app_profile" {
+  name = "${var.project_name}-instance-profile"
+  role = aws_iam_role.app_role.name
 }
 
 data "aws_ami" "ubuntu_gpu" {
@@ -46,65 +103,54 @@ resource "aws_instance" "app" {
   key_name      = var.key_name
 
   vpc_security_group_ids = [aws_security_group.app_sg.id]
+  iam_instance_profile   = aws_iam_instance_profile.app_profile.name
 
   user_data_replace_on_change = true
 
+  # Issue 48: Secret 하드코딩 제거 — SSM Parameter Store에서 런타임 조회
   user_data = <<-EOF
 #!/bin/bash
-# 로그 출력 설정
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
-
 echo "Starting Infrastructure Setup..."
 
-# 1. 시스템 업데이트 및 필수 패키지 설치
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
-apt-get install -y curl git jq build-essential ca-certificates gnupg lsb-release
+apt-get install -y curl git jq build-essential ca-certificates gnupg lsb-release awscli
 
-# 2. NVIDIA 드라이버 설치 (g4dn 인스턴스용)
-echo "Installing NVIDIA Drivers..."
-apt-get install -y ubuntu-drivers-common
-ubuntu-drivers autoinstall
+# NVIDIA 드라이버
+apt-get install -y ubuntu-drivers-common && ubuntu-drivers autoinstall
 
-# 3. Docker 공식 레포지토리 추가 및 설치
-echo "Installing Docker..."
+# Docker
 mkdir -p /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get update -y && apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+systemctl enable docker && systemctl start docker
 
-apt-get update -y
-apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+# NVIDIA Container Toolkit
+distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L "https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list" | \
+  sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+  tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+apt-get update -y && apt-get install -y nvidia-container-toolkit
+nvidia-ctk runtime configure --runtime=docker && systemctl restart docker
 
-systemctl enable docker
-systemctl start docker
-
-# 4. NVIDIA Container Toolkit 설치
-echo "Installing NVIDIA Container Toolkit..."
-distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
-  && curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
-  && curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \
-    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
-    tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
-
-apt-get update -y
-apt-get install -y nvidia-container-toolkit
-nvidia-ctk runtime configure --runtime=docker
-systemctl restart docker
-
-# 5. 프로젝트 환경 준비
-echo "Setting up project code..."
-mkdir -p /home/ubuntu/app
-cd /home/ubuntu/app
-
-# 레포지토리 클론 (현재 작업 중인 브랜치 반영을 위해 전체 클론 후 전환)
+# 프로젝트 코드
+mkdir -p /home/ubuntu/app && cd /home/ubuntu/app
 git clone https://github.com/csu-context/context-rag-chatbot.git .
-# 주의: 푸시된 브랜치가 없다면 아래 명령은 실패할 수 있으나 기본 브랜치로 동작함
-git checkout feature/issue-89-local-infra || echo "Branch not found, using default"
+git checkout develop || echo "Using default branch"
 
-# 6. .env 파일 자동 생성
-echo "Creating .env file..."
+# Issue 48: .env 생성 — 민감 정보는 SSM Parameter Store에서 런타임 조회
+echo "Fetching secrets from SSM Parameter Store..."
+REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/region)
+PREFIX="${var.ssm_parameter_prefix}"
+
+get_ssm() {
+  aws ssm get-parameter --name "$PREFIX/$1" --with-decryption \
+    --region "$REGION" --query "Parameter.Value" --output text 2>/dev/null || echo ""
+}
+
 cat <<EOT > .env
 MODEL_TYPE=ollama
 MODEL_NAME=llama3.2:1b
@@ -114,17 +160,15 @@ CHROMA_SERVER_HOST=chromadb
 CHROMA_SERVER_PORT=8000
 PARSER_TYPE=manual
 RETRIEVER_TYPE=hybrid
-DATA_PATH=./data
-DB_PATH=./vector_db
+ANTHROPIC_API_KEY=$(get_ssm "ANTHROPIC_API_KEY")
+GOOGLE_API_KEY=$(get_ssm "GOOGLE_API_KEY")
+APP_PASSWORD=$(get_ssm "APP_PASSWORD")
+ADMIN_PASSWORD=$(get_ssm "ADMIN_PASSWORD")
 EOT
 
 chown -R ubuntu:ubuntu /home/ubuntu/app
-
-# 7. Docker Compose 실행 (전체 서비스 기동)
-echo "Starting services with docker-compose..."
 docker compose up -d
-
-echo "Infrastructure & Application Setup Completed!"
+echo "Setup Completed!"
 EOF
 
   root_block_device {

--- a/terraform/modules/ec2/variables.tf
+++ b/terraform/modules/ec2/variables.tf
@@ -25,3 +25,29 @@ variable "key_name" {
   type        = string
   default     = null
 }
+
+# Issue 45/47: 접근 허용 IP 대역 (0.0.0.0/0 전체 개방 금지)
+variable "allowed_cidr_blocks" {
+  description = "Streamlit UI 접속 허용 CIDR 대역 (예: [\"1.2.3.0/24\"]). 비어있으면 외부 접근 불가."
+  type        = list(string)
+  default     = []
+}
+
+variable "allowed_ssh_cidr_blocks" {
+  description = "SSH 허용 CIDR 대역 — 운영팀 IP만 등록 (예: [\"10.0.0.0/8\"])"
+  type        = list(string)
+  default     = []
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR 블록 (백엔드 포트 내부 접근 제한용)"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+# Issue 48: user_data Secret 하드코딩 방지 — SSM Parameter Store 사용
+variable "ssm_parameter_prefix" {
+  description = "SSM Parameter Store 경로 prefix (예: /rag-chatbot/dev)"
+  type        = string
+  default     = "/rag-chatbot/dev"
+}

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -5,3 +5,7 @@ output "vpc_id" {
 output "public_subnet_id" {
   value = aws_subnet.public.id
 }
+
+output "vpc_cidr" {
+  value = aws_vpc.main.cidr_block
+}


### PR DESCRIPTION
## 변경 사항 (Checklist)
* [x] 새로운 기능 추가 (feature)
* [x] 버그 수정 (fix)
* [x] 리팩토링 (refactor)
* [ ] 문서 수정 (docs)
* [x] 환경 설정 (setup)

## 주요 작업 내용

1. **Terraform 방화벽 규칙 강화 및 포트 격리**
   - `terraform/modules/ec2/main.tf`: SSH(22) 인바운드를 `allowed_cidr` 변수로 제한하여 `0.0.0.0/0` 전체 개방 차단.
   - `terraform/modules/vpc/outputs.tf`: 백엔드 DB(ChromaDB 8000)/LLM(Ollama 11434) 포트를 VPC 내부 전용으로 격리하여 외부 데이터 탈취·자원 하이재킹 차단.
   - `terraform/environments/dev/variables.tf`: `allowed_cidr` 변수 외부화로 환경별(개발/운영) 허용 IP 분리 관리 지원.

2. **EC2 Secret 하드코딩 제거 및 안전한 주입**
   - `terraform/modules/ec2/main.tf`: User Data 내 Secret 하드코딩 제거, AWS Secrets Manager에서 런타임에 주입하도록 전환.
   - `.env.example`: 환경변수 템플릿 정비 — `APP_PASSWORD`, `ADMIN_PASSWORD`, `ALLOWED_CIDR` 항목 추가.

3. **앱 전체 인증 게이트 및 관리자 인증**
   - `src/app.py`: `APP_PASSWORD` 설정 시 앱 진입 시점에 패스워드 인증 게이트 적용. 미인증 상태에서 `st.stop()`으로 이후 렌더링 차단.
   - `src/ui/dialogs/admin.py`: `ADMIN_PASSWORD` 설정 시 관리자 패널 진입 전 인증 요구. 인증 성공 여부를 세션 상태로 관리.

4. **Semantic Cache 권한별 격리**
   - `src/core/cache.py`: 캐시 키에 사용자 권한 컨텍스트를 포함시켜 권한별 캐시 분리. 다른 권한 레벨의 캐시 결과가 교차 반환되는 우려 제거.

5. **프롬프트 인젝션 방어 강화**
   - `src/core/nodes.py`: 사용자 입력 및 문서 컨텍스트 내 XML 태그 이스케이프 처리로 프롬프트 샌드박스 탈옥 차단.
   - `src/core/chains.py`: Multi-turn 대화 히스토리 sanitization — 이전 메시지에 포함된 인젝션 시도를 중립화.

6. **Docker 컨테이너 Root 권한 제거**
   - `Dockerfile`: `USER appuser` 설정으로 non-root 실행. 컨테이너 탈출 시 호스트 권한 획득 경로 차단.

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**:
  - Terraform 보안 그룹이 SSH·UI·백엔드 포트 전부를 `0.0.0.0/0`으로 개방하여 무차별 대입 및 API 자원 하이재킹에 노출.
  - EC2 User Data에 API 키·패스워드가 평문 하드코딩되어 `terraform state` 열람만으로 Secret 탈취 가능.
  - 관리자 패널에 인증 없이 접근 가능하여 문서 동기화·캐시 초기화 등 파괴적 작업을 누구나 실행 가능.
  - Streamlit `@st.cache_resource` 기반 Semantic Cache가 세션 구분 없이 공유되어 권한이 다른 사용자 간 응답 교차 반환 우려.
  - 사용자 입력 및 RAG 검색 문서에 포함된 XML 태그가 시스템 프롬프트 구조를 깨뜨려 프롬프트 샌드박스 탈옥 가능.

* **원인 분석**:
  - Terraform 초기 설정 시 개발 편의를 위해 전체 개방으로 설정한 뒤 운영 전환 시 미수정.
  - `user_data` 블록이 Terraform state 파일에 그대로 저장되므로 S3 버킷 접근 권한만 있으면 평문 노출.
  - Streamlit 캐시 키가 쿼리 텍스트만으로 구성되어 권한 컨텍스트가 누락.
  - LLM 프롬프트가 XML 태그로 구조화되어 있어 사용자 입력에 포함된 동명 태그가 프롬프트 경계를 무너뜨림.

* **해결 방안 및 의사결정**:
  - **최소 권한 원칙**: SSH는 운영팀 CIDR로, 백엔드 서비스 포트는 VPC 내부로 제한. UI는 ALB/Nginx 경유 강제.
  - **Secret 외부화**: Terraform `user_data`에서 Secret을 제거하고 AWS Secrets Manager에서 런타임 주입. `.env.example`로 필수 환경변수 명시.
  - **캐시 격리**: 캐시 키 생성 시 사용자 권한 해시를 포함시켜 권한 간 캐시 경계 강제.
  - **XML 이스케이프**: `<`, `>`, `&` 문자를 HTML 엔티티로 치환하여 프롬프트 구조 보호. 대화 히스토리도 동일 처리.

* **결과**:
  - `nmap` 외부 스캔 시 SSH·백엔드 포트 비응답 확인.
  - Terraform state에 Secret 평문 미포함 확인.
  - 인증 없이 관리자 패널 접근 시 인증 UI 표시 및 기능 차단 확인.
  - XML 인젝션 페이로드가 LLM 프롬프트 구조에 영향 없음 확인.

## 테스트 결과 / 결과 증빙 (Screenshots / Logs)

### 1. 앱 인증 게이트 동작 확인

```bash
# APP_PASSWORD 설정 후 앱 접속 시 로그인 화면 표시 확인
# 올바른 패스워드 입력 시 세션 유지, 잘못된 입력 시 오류 메시지 표시
```

### 2. Terraform 보안 그룹 검증

```bash
terraform plan
# → aws_security_group.app: ingress 22 cidr = var.allowed_cidr (0.0.0.0/0 없음)
# → ChromaDB(8000), Ollama(11434) 외부 노출 없음
```

### 3. 단위 테스트 전체 통과

```bash
pytest src/tests/unit/
====================== passed, warnings in (실행 결과 첨부 예정) =======================
```

## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요?
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
* [x] 관련 이슈 번호를 연결했나요? (Closes #133)
* [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디

> Epic 7은 서비스 보안의 기반을 다지는 작업으로, P0 취약점 7건·P1 5건을 포함한 총 13개 보안 이슈를 일괄 해결했습니다.
> 인프라 접근 제어(Terraform)부터 애플리케이션 레이어 인증·프롬프트 방어·컨테이너 권한까지 전 계층을 커버하였으니 꼼꼼한 보안 리뷰 부탁드립니다!