### PR TITLE
feat(eval): 평가 파이프라인 (#144)

### DIFF
--- a/src/common/config.py
+++ b/src/common/config.py
@@ -53,6 +53,7 @@ class Settings(BaseSettings):
     RRF_K: int = 60
     HYBRID_WEIGHT_BM25: float = 0.5
     HYBRID_WEIGHT_VECTOR: float = 0.5
+    RETRIEVAL_K: int = Field(default=50)
     RETRIEVER_CANDIDATE_POOL_MIN: int = Field(default=15)
     # 하이브리드 검색 두 leg 병렬 실행용 공유 스레드풀 크기 (동시 쿼리 x 2 leg 수용)
     RETRIEVER_EXECUTOR_MAX_WORKERS: int = Field(default=8)
@@ -123,6 +124,8 @@ class Settings(BaseSettings):
     EVAL_JUDGE_MODEL: str = "claude-haiku-4-5"
     EVAL_DATA_GEN_TYPE: str = "claude"
     EVAL_DATA_GEN_MODEL: str = "claude-haiku-4-5"
+    EVAL_DATA_GEN_SAMPLES: int = Field(default=50)
+    EVAL_MAX_WORKERS: int = Field(default=2)
 
     # 6. 인프라 및 경로 설정
     LOG_LEVEL: str = "INFO"

--- a/src/core/chains.py
+++ b/src/core/chains.py
@@ -12,6 +12,7 @@ from langchain_core.documents import Document
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnableLambda
 
+from src.common.config import settings
 from src.common.constants import MetadataFields
 from src.core.cache import SemanticCache
 from src.core.nodes import _MAX_HISTORY_MESSAGES, ContextBuilderNode
@@ -48,12 +49,12 @@ def invalidate_source_json_cache() -> None:
 class RAGPipeline:
     """RAG 파이프라인의 핵심 로직을 관리하는 클래스"""
 
-    def __init__(self, retriever_or_db: Any, llm: Any = None, reranker: Any = None):
+    def __init__(self, retriever_or_db: Any, llm: Any = None, reranker: Any = None, use_cache: bool = True):
         self.retriever_or_db = retriever_or_db
         self.llm = llm or LLMFactory.create_llm_with_fallback()
         self.reranker = reranker or RerankerFactory.create()
         self.tracing_logger = TracingLogger()
-        self.cache = SemanticCache()
+        self.cache = SemanticCache() if use_cache else None
 
     def _resolve_parent_documents(self, docs: list[Document]) -> list[Document]:
         """자식 청크로 검색된 문서들을 부모 청크의 원문으로 전환하며, 동일 부모 및 동일 텍스트 중복을 제거합니다."""
@@ -285,14 +286,14 @@ class RAGPipeline:
     def stream(self, input_dict: dict[str, Any]) -> Iterator[dict[str, Any]]:
         """전체 RAG 파이프라인을 스트리밍 모드로 실행합니다."""
         query = input_dict.get("question", "")
-        retrieval_k = input_dict.get("k", 20)
+        retrieval_k = input_dict.get("k", settings.RETRIEVAL_K)
         final_k = input_dict.get("final_k", 5)
         history = input_dict.get("history", [])
 
         with self.tracing_logger.start_session(query=query) as session:
             # 1. Semantic Cache Check
             yield {"stage": "cache", "status": "running"}
-            cached_result = self.cache.get(query)
+            cached_result = self.cache.get(query) if self.cache else None
             if cached_result:
                 session.data["cache_hit"] = True
                 yield {"stage": "cache", "status": "hit"}
@@ -342,12 +343,13 @@ class RAGPipeline:
                 for doc in final_docs
             ]
 
-            self.cache.add(query, full_answer, docs_for_cache)
+            if self.cache:
+                self.cache.add(query, full_answer, docs_for_cache)
 
             yield {"stage": "citation", "status": "complete", "output": citations_str, "source_documents": final_docs}
 
 
-def get_rag_chain(retriever_or_db):
+def get_rag_chain(retriever_or_db, llm: Any = None, use_cache: bool = True):
     """RAG 파이프라인 체인을 생성합니다. LangChain Runnable 인터페이스를 준수합니다."""
     from src.common.config import settings
 
@@ -356,5 +358,5 @@ def get_rag_chain(retriever_or_db):
         os.environ.setdefault("LANGSMITH_TRACING", "true")
         logger.info("LangSmith 트레이싱 활성화됨 (LANGSMITH_TRACING=True)")
 
-    pipeline = RAGPipeline(retriever_or_db)
+    pipeline = RAGPipeline(retriever_or_db, llm=llm, use_cache=use_cache)
     return RunnableLambda(pipeline.stream)

--- a/src/eval/dataset_generator.py
+++ b/src/eval/dataset_generator.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import random
 from pathlib import Path
 from typing import Any
@@ -9,14 +8,15 @@ from dotenv import load_dotenv
 from langchain_core.prompts import ChatPromptTemplate
 from tqdm import tqdm
 
+from src.common.config import settings
 from src.models.factory import LLMFactory
+from src.utils.logger import setup_global_logging
 from src.utils.paths import EVAL_DATA_DIR, PROCESSED_DATA_DIR
 
-# 로깅 설정
-logging.basicConfig(level=logging.INFO)
+setup_global_logging()
 logger = logging.getLogger(__name__)
 
-load_dotenv()
+load_dotenv(override=False)
 
 GENERATION_PROMPT = """
 당신은 RAG(Retrieval-Augmented Generation) 시스템의 평가를 위한 정답 데이터셋(Golden Dataset) 제작 전문가입니다.
@@ -42,57 +42,61 @@ GENERATION_PROMPT = """
 
 class GoldenDatasetGenerator:
     def __init__(self, model_type: str = "claude", model_name: str = "claude-haiku-4-5"):
-        # 비용 효율을 위해 Haiku 모델 사용 (기존: claude-sonnet-4-6)
         self.llm_instance = LLMFactory.create_llm(model_type=model_type, model_name=model_name, temperature=0.3)
-        self.prompt = ChatPromptTemplate.from_template(GENERATION_PROMPT)
-        # LLMFactory 인스턴스에서 LangChain 모델 객체 추출
-        self.llm = self.llm_instance.get_model()
-        self.chain = self.prompt | self.llm
+        if hasattr(self.llm_instance, "warmup"):
+            self.llm_instance.warmup()
+        self.prompt_template = ChatPromptTemplate.from_template(GENERATION_PROMPT)
 
-    def load_processed_data(self, file_path: Path) -> list[dict[str, Any]]:
+    @staticmethod
+    def load_processed_data(file_path: Path) -> list[dict[str, Any]]:
         with open(file_path, encoding="utf-8") as f:
             return json.load(f)
 
-    def generate_pair(self, context: str) -> dict[str, str] | None:
+    @staticmethod
+    def _extract_json(content: Any) -> dict[str, str] | None:
+        """LLM 응답에서 JSON 파싱."""
         try:
-            response = self.chain.invoke({"context": context})
-            content = response.content
-
-            # content가 리스트인 경우 처리
             if isinstance(content, list):
-                text_parts = [part.get("text", "") if isinstance(part, dict) else str(part) for part in content]
-                content = "".join(text_parts)
+                content = "".join(part.get("text", "") if isinstance(part, dict) else str(part) for part in content)
             else:
                 content = str(content)
 
-            # JSON 파싱 시도
             if "```json" in content:
                 content = content.split("```json")[1].split("```")[0].strip()
             elif "```" in content:
                 content = content.split("```")[1].split("```")[0].strip()
 
             return json.loads(content)
-        except Exception as e:
-            logger.error(f"데이터 생성 중 오류 발생: {e}")
+        except Exception:
             return None
 
-    def run(self, input_file: Path, output_file: Path, num_samples: int = 20):
-        data = self.load_processed_data(input_file)
+    def run(self, input_files: list[Path], output_file: Path, num_samples: int = 50):
+        chunk_pool: list[tuple[str, str, str]] = []
+        for input_file in input_files:
+            data = self.load_processed_data(input_file)
+            chunk_pool += [
+                (
+                    child["text"],
+                    parent.get("metadata", {}).get("relative_path", "unknown"),
+                    parent.get("metadata", {}).get("source_id", "unknown"),
+                )
+                for parent in data
+                for child in parent.get("children", [])
+                if len(child["text"]) > 150
+            ]
+        chunk_pool = [
+            (text, src, sid)
+            for text, src, sid in chunk_pool
+            if sum(1 for ch in text if "가" <= ch <= "힣") / len(text) > 0.3
+        ]
+        chunk_pool = list({text: (text, src, sid) for text, src, sid in chunk_pool}.values())
 
-        # ... (기존 필터링 로직)
-        all_chunks = []
-        for parent in data:
-            for child in parent.get("children", []):
-                all_chunks.append(child["text"])
+        if not chunk_pool:
+            logger.error("유효한 청크가 없습니다. 필터 조건을 확인하세요.")
+            return
 
-        all_chunks = list(set([c for c in all_chunks if len(c) > 150]))
-        filtered_chunks = [c for c in all_chunks if len([char for char in c if "가" <= char <= "힣"]) / len(c) > 0.3]
-        all_chunks = filtered_chunks
-
-        if len(all_chunks) < num_samples:
-            num_samples = len(all_chunks)
-
-        samples = random.sample(all_chunks, num_samples)
+        num_samples = min(num_samples, len(chunk_pool))
+        samples = random.sample(chunk_pool, num_samples)
 
         golden_dataset = []
         total_input_tokens = 0
@@ -101,16 +105,15 @@ class GoldenDatasetGenerator:
 
         logger.info(f"{num_samples}개의 평가 데이터 생성을 시작합니다.")
 
-        for context in tqdm(samples):
+        for context, source, source_id in tqdm(samples):
             try:
-                # LLMFactory 인스턴스의 invoke를 직접 호출하여 토큰 정보를 가져오기 위해 로직 약간 수정
-                prompt_template = ChatPromptTemplate.from_template(GENERATION_PROMPT)
-                prompt_val = prompt_template.invoke({"context": context})
-
+                prompt_val = self.prompt_template.invoke({"context": context})
                 response_obj = self.llm_instance.invoke(prompt_val)
-                pair = self.generate_pair_from_response(response_obj)
+                pair = self._extract_json(response_obj.content)
 
                 if pair:
+                    pair["source"] = source
+                    pair["source_id"] = source_id
                     golden_dataset.append(pair)
                     total_cost += response_obj.cost
                     if response_obj.usage:
@@ -123,49 +126,25 @@ class GoldenDatasetGenerator:
         with open(output_file, "w", encoding="utf-8") as f:
             json.dump(golden_dataset, f, ensure_ascii=False, indent=4)
 
-        logger.info(f"성공적으로 {len(golden_dataset)}개의 데이터를 저장했습니다.")
-        print("\n" + "=" * 40)
-        print("   데이터 생성 비용 요약 (Estimated Cost)")
-        print("-" * 40)
-        print(f"- 사용 모델: {self.llm_instance.model_name}")
-        print(f"- 총 입력 토큰: {total_input_tokens:,}")
-        print(f"- 총 출력 토큰: {total_output_tokens:,}")
-        print(f"- 예상 합계 비용: ${total_cost:.4f}")
-        print("=" * 40)
-
-    def generate_pair_from_response(self, response_obj) -> dict[str, str] | None:
-        """LLMResponse 객체에서 정답 쌍을 파싱합니다."""
-        try:
-            content = response_obj.content
-            if isinstance(content, list):
-                content = "".join([part.get("text", "") if isinstance(part, dict) else str(part) for part in content])
-
-            if "```json" in content:
-                content = content.split("```json")[1].split("```")[0].strip()
-            elif "```" in content:
-                content = content.split("```")[1].split("```")[0].strip()
-
-            return json.loads(content)
-        except Exception:
-            return None
+        logger.info(f"데이터 저장 완료: {len(golden_dataset)}개 → {output_file}")
+        logger.info(f"모델: {self.llm_instance.model_name}")
+        logger.info(f"입력 토큰: {total_input_tokens:,} / 출력 토큰: {total_output_tokens:,}")
+        logger.info(f"예상 비용: ${total_cost:.4f}")
 
 
 if __name__ == "__main__":
-    # 가장 최근의 전처리 파일 찾기
-    processed_dir = PROCESSED_DATA_DIR
-    json_files = sorted(processed_dir.glob("preprocessed_*.json"), key=os.path.getmtime, reverse=True)
+    json_files = [f for f in PROCESSED_DATA_DIR.glob("*.json") if f.name != "manifest.json"]
 
     if not json_files:
-        print("전처리된 JSON 파일을 찾을 수 없습니다.")
+        logger.error("전처리된 JSON 파일을 찾을 수 없습니다.")
     else:
-        latest_file = json_files[0]
-        # 최신 파싱 결과를 반영한 신규 합성 데이터셋
-        output_path = EVAL_DATA_DIR / "synthetic_dataset_50.json"
-
-        # 데이터셋 생성용 모델 설정 (기본값: Claude)
-        gen_type = os.getenv("EVAL_DATA_GEN_TYPE", "claude")
-        gen_model = os.getenv("EVAL_DATA_GEN_MODEL", "claude-haiku-4-5")
-
-        generator = GoldenDatasetGenerator(model_type=gen_type, model_name=gen_model)
-        # 50개 샘플 생성
-        generator.run(latest_file, output_path, num_samples=50)
+        logger.info(f"대상 파일 {len(json_files)}개: {[f.name for f in json_files]}")
+        generator = GoldenDatasetGenerator(
+            model_type=settings.EVAL_DATA_GEN_TYPE,
+            model_name=settings.EVAL_DATA_GEN_MODEL,
+        )
+        generator.run(
+            input_files=json_files,
+            output_file=EVAL_DATA_DIR / "synthetic_dataset_50.json",
+            num_samples=settings.EVAL_DATA_GEN_SAMPLES,
+        )

--- a/src/eval/evaluator.py
+++ b/src/eval/evaluator.py
@@ -1,64 +1,193 @@
 import asyncio
+import inspect
 import json
 import logging
+import math
 import os
+import platform
+import subprocess
 import time
 import warnings
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
+import instructor
+import pandas as pd
+import psutil
+from anthropic import AsyncAnthropic
 from dotenv import load_dotenv
-from langchain_huggingface import HuggingFaceEmbeddings
-from ragas import EvaluationDataset
-from ragas.embeddings import LangchainEmbeddingsWrapper
-from ragas.evaluation import EvaluationResult, evaluate  # type: ignore
-from ragas.llms import LangchainLLMWrapper
-
-# Metrics 임포트 (Pylance 경고 차단)
-from ragas.metrics import (  # type: ignore
+from ragas import SingleTurnSample
+from ragas.embeddings import HuggingFaceEmbeddings as RagasHFEmbeddings
+from ragas.llms import InstructorLLM
+from ragas.metrics.collections import (
     AnswerRelevancy,
     ContextPrecision,
     ContextRecall,
     Faithfulness,
 )
-from ragas.run_config import RunConfig
 
+from src.common.config import settings
+from src.core.retriever import RetrieverFactory
 from src.models.factory import LLMFactory
 from src.utils.logger import setup_global_logging
-from src.utils.paths import EVAL_DATA_DIR, EVAL_LOGS_DIR
-from src.vector_db.chroma_manager import ChromaDBManager
+from src.utils.paths import EVAL_DATA_DIR, EVAL_LOGS_DIR, PROCESSED_DATA_DIR
 
-# 평가 관련 기본 설정 상수
-DEFAULT_EVAL_MODEL = "claude-haiku-4-5-20251001"
-DEFAULT_MAX_WORKERS = 2
-DEFAULT_EVAL_TIMEOUT = 180
 DEFAULT_GOLDEN_SET_PATH = EVAL_DATA_DIR / "synthetic_dataset_50.json"
+SECTION_LINE = "─" * 49
 
-# 라이브러리 내부의 DeprecationWarning 및 런타임 경고 완전 차단
-warnings.filterwarnings("ignore")
+# 외부 라이브러리(ragas, langchain, huggingface, anthropic 등)의 Deprecation/Future 경고만 모듈 단위로 차단.
+# 전역 차단(filterwarnings("ignore"))은 자체 코드의 경고까지 가리므로 사용하지 않는다.
+_NOISY_MODULES = (
+    "ragas",
+    "langchain",
+    "langchain_huggingface",
+    "huggingface_hub",
+    "transformers",
+    "sentence_transformers",
+    "anthropic",
+    "instructor",
+)
+for _noisy_module in _NOISY_MODULES:
+    warnings.filterwarnings("ignore", category=DeprecationWarning, module=_noisy_module)
+    warnings.filterwarnings("ignore", category=FutureWarning, module=_noisy_module)
 
 # 로깅 설정
 setup_global_logging()
 logger = logging.getLogger(__name__)
 
-load_dotenv(override=True)
+load_dotenv(override=False)
 
 
-async def run_rag_inference(test_data: list[dict[str, Any]]) -> tuple[EvaluationDataset, str]:
-    """RAG 추론 수행 및 Ragas EvaluationDataset 생성 (시스템 표준 체인 사용)"""
+@dataclass
+class InferenceResult:
+    samples: list[SingleTurnSample]
+    latencies: list[float]
+    resources: list[dict[str, float]]
+    model_name: str
+
+
+def _get_cpu_name() -> str:
+    try:
+        if platform.system() == "Linux":
+            with open("/proc/cpuinfo", encoding="utf-8") as f:
+                for line in f:
+                    if line.startswith("model name"):
+                        return line.split(":", 1)[1].strip()
+        if platform.system() == "Windows":
+            out = subprocess.check_output(
+                ["powershell", "-Command", "(Get-CimInstance -ClassName Win32_Processor).Name"],
+                text=True,
+                timeout=5,
+            )
+            return out.strip()
+    except Exception:
+        pass
+    return platform.processor() or platform.machine()
+
+
+def _get_system_info() -> dict[str, Any]:
+    mem = psutil.virtual_memory()
+    info: dict[str, Any] = {
+        "os": f"{platform.system()} {platform.release()}",
+        "python": platform.python_version(),
+        "cpu": _get_cpu_name(),
+        "cpu_cores": psutil.cpu_count(logical=False),
+        "cpu_threads": psutil.cpu_count(logical=True),
+        "ram_total_gb": round(mem.total / 1024 / 1024 / 1024, 1),
+    }
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=name,memory.total", "--format=csv,noheader,nounits"],
+            text=True,
+            timeout=3,
+        )
+        name, total = out.strip().splitlines()[0].split(",")
+        info["gpu"] = name.strip()
+        info["gpu_vram_total_mb"] = float(total.strip())
+    except Exception:
+        info["gpu"] = None
+        info["gpu_vram_total_mb"] = None
+    return info
+
+
+def _get_indexed_documents() -> list[str]:
+    try:
+        paths = sorted([f for f in PROCESSED_DATA_DIR.glob("*.json") if f.name != "manifest.json"])
+        docs = []
+        for path in paths:
+            with open(path, encoding="utf-8") as f:
+                for line in f:
+                    if '"relative_path"' in line:
+                        value = line.split('"relative_path"', 1)[1]
+                        value = value.split('"', 2)
+                        if len(value) >= 3:
+                            docs.append(value[1])
+                        break
+        return sorted(set(docs))
+    except Exception:
+        return []
+
+
+def _get_vram_mb() -> float | None:
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=memory.used", "--format=csv,noheader,nounits"],
+            text=True,
+            timeout=3,
+        )
+        return float(out.strip().splitlines()[0])
+    except Exception:
+        return None
+
+
+def _get_resource_snapshot() -> dict[str, float]:
+    mem = psutil.virtual_memory()
+    snapshot: dict[str, float] = {
+        "cpu_percent": psutil.cpu_percent(interval=None),
+        "ram_mb": round(mem.used / 1024 / 1024, 1),
+    }
+    vram = _get_vram_mb()
+    if vram is not None:
+        snapshot["vram_mb"] = vram
+    return snapshot
+
+
+async def run_rag_inference(test_data: list[dict[str, Any]]) -> InferenceResult:
+    """RAG 추론 수행 및 SingleTurnSample 리스트 생성 (시스템 표준 체인 사용)"""
     from src.core.chains import get_rag_chain
 
-    db_manager = ChromaDBManager()
-    # 시스템 표준 RAG 체인 초기화
-    rag_chain = get_rag_chain(db_manager)
+    retriever = RetrieverFactory.create_retriever()
+    logger.info(SECTION_LINE)
+    logger.info("파이프라인 설정")
+    logger.info(
+        f"  Retriever : {settings.RETRIEVER_TYPE:<8} "
+        f"(BM25 w={settings.HYBRID_WEIGHT_BM25} / Vector w={settings.HYBRID_WEIGHT_VECTOR} / k={settings.RETRIEVAL_K})"
+    )
+    logger.info(
+        f"  Reranker  : {settings.RERANKER_TYPE:<8} "
+        f"({settings.RERANKER_MODEL_NAME} / top_k={settings.RERANKER_MAX_DOCS})"
+    )
+    logger.info(f"  LLM       : {settings.MODEL_TYPE:<8} ({settings.MODEL_NAME})")
+    logger.info(SECTION_LINE)
 
-    # 모델 정보 획득 (로깅용)
     temp_llm = LLMFactory.create_llm()
     model_name = str(temp_llm.model_name)
 
-    samples = []
-    logger.info(f"{len(test_data)}개 샘플 추론 시작 (모델: {model_name})")
+    if hasattr(temp_llm, "warmup"):
+        temp_llm.warmup()
+
+    chroma_target = getattr(retriever, "chroma", retriever)
+    if hasattr(chroma_target, "embedder"):
+        _ = chroma_target.embedder
+
+    rag_chain = get_rag_chain(retriever, llm=temp_llm.get_model(), use_cache=False)
+
+    samples: list[SingleTurnSample] = []
+    latencies: list[float] = []
+    resources: list[dict[str, float]] = []
+    logger.info(f"[추론] {len(test_data)}개 샘플 시작 (모델: {model_name})")
 
     for i, row in enumerate(test_data):
         question = row["question"]
@@ -69,7 +198,6 @@ async def run_rag_inference(test_data: list[dict[str, Any]]) -> tuple[Evaluation
             full_response = ""
             source_docs = []
 
-            # 스트리밍 파이프라인 소비
             for step in rag_chain.stream({"question": question}):
                 stage = step.get("stage")
                 status = step.get("status")
@@ -79,29 +207,149 @@ async def run_rag_inference(test_data: list[dict[str, Any]]) -> tuple[Evaluation
                 elif stage == "citation" and status == "complete":
                     source_docs = step.get("source_documents", [])
 
-            # Ragas 평가를 위해 검색된 문서들의 텍스트 추출 (이중 검색 제거)
             contexts = [doc.page_content for doc in source_docs]
-
-            # 답변 본문 사용
             answer = full_response.strip()
-
             latency = time.time() - start_time
 
             logger.info(f"[{i + 1}/{len(test_data)}] 성공 ({latency:.2f}s)")
 
             samples.append(
-                {
-                    "user_input": question,
-                    "response": answer,
-                    "retrieved_contexts": contexts,
-                    "reference": ground_truth,
-                    "latency_sec": latency,
-                }
+                SingleTurnSample(
+                    user_input=question,
+                    response=answer,
+                    retrieved_contexts=contexts,
+                    reference=ground_truth,
+                )
             )
+            latencies.append(latency)
+            resources.append(_get_resource_snapshot())
         except Exception as e:
             logger.error(f"오류 발생 ({question[:20]}...): {e}")
 
-    return EvaluationDataset.from_list(samples), model_name
+    return InferenceResult(samples=samples, latencies=latencies, resources=resources, model_name=model_name)
+
+
+async def _score_and_save(result: InferenceResult, missing_docs: list[str] | None = None) -> None:
+    """메트릭 초기화, 샘플별 스코어링, 결과 저장"""
+    logger.info(SECTION_LINE)
+    logger.info("평가 판사 설정")
+    logger.info(f"  Judge LLM : {settings.EVAL_JUDGE_TYPE:<8} ({settings.EVAL_JUDGE_MODEL})")
+    logger.info(f"  Embedding : {settings.EMBEDDING_MODEL_NAME}")
+    logger.info(SECTION_LINE)
+
+    instructor_client = instructor.from_anthropic(AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY))
+    ragas_llm = InstructorLLM(
+        client=instructor_client,
+        model=settings.EVAL_JUDGE_MODEL,
+        provider="anthropic",
+        temperature=0,
+    )
+    ragas_llm.model_args.pop("top_p", None)
+    ragas_embeddings = RagasHFEmbeddings(model=settings.EMBEDDING_MODEL_NAME)
+
+    metrics = [
+        Faithfulness(llm=ragas_llm),
+        AnswerRelevancy(llm=ragas_llm, embeddings=ragas_embeddings),
+        ContextPrecision(llm=ragas_llm),
+        ContextRecall(llm=ragas_llm),
+    ]
+
+    sem = asyncio.Semaphore(settings.EVAL_MAX_WORKERS)
+    metric_params = {m: set(inspect.signature(m.ascore).parameters) for m in metrics}
+
+    async def _ascore(metric: Any, sample: SingleTurnSample) -> float:
+        all_kwargs = {
+            "user_input": sample.user_input or "",
+            "response": sample.response or "",
+            "retrieved_contexts": sample.retrieved_contexts or [],
+            "reference": sample.reference or "",
+        }
+        kwargs = {k: v for k, v in all_kwargs.items() if k in metric_params[metric]}
+        async with sem:
+            result_obj = await metric.ascore(**kwargs)
+        return float(result_obj.value)
+
+    logger.info(f"[스코어링] {len(result.samples)}개 샘플 시작")
+
+    scored_rows: list[dict[str, Any]] = []
+    for i, (sample, latency, resource) in enumerate(
+        zip(result.samples, result.latencies, result.resources, strict=False)
+    ):
+        try:
+            scores = await asyncio.gather(*[_ascore(m, sample) for m in metrics])
+            row: dict[str, Any] = {m.name: s for m, s in zip(metrics, scores, strict=False)}
+        except Exception as e:
+            logger.error(f"샘플 {i + 1} 스코어링 실패: {e}")
+            row = {m.name: float("nan") for m in metrics}
+        row["latency_sec"] = latency
+        row.update(resource)
+        scored_rows.append(row)
+
+        if (i + 1) % 10 == 0 or (i + 1) == len(result.samples):
+            interim_df = pd.DataFrame(scored_rows)
+            interim_scores = " / ".join(
+                f"{name}: {interim_df[name].mean():.4f}"
+                for name in [m.name for m in metrics]
+                if name in interim_df.columns
+            )
+            avg_latency = interim_df["latency_sec"].mean()
+            logger.info(f"[{i + 1}/{len(result.samples)}] 중간 점수 — {interim_scores} / latency: {avg_latency:.2f}s")
+
+    df = pd.DataFrame(scored_rows)
+    metric_names = [m.name for m in metrics]
+    avg_scores: dict[str, float] = {
+        name: float(df[name].mean()) for name in metric_names if name in df.columns and not math.isnan(df[name].mean())
+    }
+
+    eval_dir = EVAL_LOGS_DIR
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    avg_latency = float(df["latency_sec"].mean()) if "latency_sec" in df.columns else 0.0
+    summary_data: dict[str, Any] = {
+        "timestamp": str(timestamp),
+        "data": {
+            "indexed_documents": _get_indexed_documents(),
+            "missing_documents": missing_docs or [],
+        },
+        "pipeline": {
+            "llm": f"{settings.MODEL_TYPE}/{result.model_name}",
+            "retriever": (
+                f"{settings.RETRIEVER_TYPE} (BM25 w={settings.HYBRID_WEIGHT_BM25}"
+                f" / Vector w={settings.HYBRID_WEIGHT_VECTOR} / k={settings.RETRIEVAL_K})"
+            ),
+            "reranker": (
+                f"{settings.RERANKER_TYPE}/{settings.RERANKER_MODEL_NAME} (top_k={settings.RERANKER_MAX_DOCS})"
+            ),
+        },
+        "judge": {
+            "llm": f"{settings.EVAL_JUDGE_TYPE}/{settings.EVAL_JUDGE_MODEL}",
+            "embedding": settings.EMBEDDING_MODEL_NAME,
+            "max_workers": settings.EVAL_MAX_WORKERS,
+        },
+        "results": {
+            **avg_scores,
+            "avg_latency_sec": avg_latency,
+            "total_samples": len(df),
+        },
+        "system": _get_system_info(),
+    }
+
+    summary_path = eval_dir / f"eval_summary_{timestamp}.json"
+    with open(summary_path, "w", encoding="utf-8") as f:
+        json.dump(summary_data, f, ensure_ascii=False, indent=4)
+
+    details_path = eval_dir / f"eval_details_{timestamp}.csv"
+    df.to_csv(details_path, index=False, encoding="utf-8-sig")
+
+    logger.info(SECTION_LINE)
+    logger.info("평가 결과")
+    for m, s in avg_scores.items():
+        logger.info(f"  {m:<24}: {s:.4f}")
+    logger.info(f"  {'avg_latency':<24}: {avg_latency:.2f}s")
+    logger.info(SECTION_LINE)
+    logger.info(f"요약 저장: {summary_path}")
+    logger.info(f"상세 저장: {details_path}")
 
 
 async def main():
@@ -113,101 +361,26 @@ async def main():
     with open(golden_path, encoding="utf-8") as f:
         data = json.load(f)
 
-    # 신규 생성된 50개 샘플 전체를 평가하기 위해 기본값 수정
-    max_samples = int(os.getenv("EVAL_MAX_SAMPLES", 50))
-    test_data = data[:max_samples]
+    missing_docs: list[str] = []
+    dataset_source_ids = {row["source_id"] for row in data if "source_id" in row}
+    if dataset_source_ids:
+        indexed_ids = {f.stem for f in PROCESSED_DATA_DIR.glob("*.json") if f.name != "manifest.json"}
+        missing_ids = dataset_source_ids - indexed_ids
+        if missing_ids:
+            missing_docs = sorted({row["source"] for row in data if row.get("source_id") in missing_ids})
+            logger.warning(
+                f"데이터셋-인덱스 불일치 감지. 누락된 문서: {missing_docs} "
+                f"(source_id: {sorted(missing_ids)}) — 평가를 계속 진행합니다."
+            )
 
-    # 1. RAG 추론 수행
-    dataset, model_name = await run_rag_inference(test_data)
+    result = await run_rag_inference(data[: settings.EVAL_MAX_SAMPLES])
 
-    if len(dataset) == 0:
+    if not result.samples:
         logger.error("유효한 추론 결과가 없습니다.")
         return
 
-    # 2. 평가 판사 및 임베딩 설정
-    eval_model_type = os.getenv("EVAL_JUDGE_TYPE", "claude")
-    eval_model_name = os.getenv("EVAL_JUDGE_MODEL", DEFAULT_EVAL_MODEL)
-
-    logger.info(f"평가 판사 설정 (Type: {eval_model_type}, Model: {eval_model_name})")
-
-    # LLMFactory를 통해 평가 판사 인스턴스 생성
-    eval_llm_inst = LLMFactory.create_llm(model_type=eval_model_type, model_name=eval_model_name, temperature=0)
-    ragas_llm = LangchainLLMWrapper(eval_llm_inst.get_model())
-
-    # 임베딩 모델 설정
-    embed_model_name = os.getenv("EVAL_EMBED_MODEL", "BAAI/bge-m3")
-    lc_embeddings = HuggingFaceEmbeddings(model_name=embed_model_name)
-    ragas_embeddings = LangchainEmbeddingsWrapper(lc_embeddings)
-
-    # 지표 리스트 (클래스 인스턴스화)
-    metrics = [
-        Faithfulness(),
-        AnswerRelevancy(),
-        ContextPrecision(),
-        ContextRecall(),
-    ]
-
-    logger.info(f"RAGAS 지표 계산 시작 (평가 모델: {eval_model_name})")
-
     try:
-        # 3. 평가 실행
-        results = evaluate(
-            dataset=dataset,
-            metrics=metrics,
-            llm=ragas_llm,
-            embeddings=ragas_embeddings,
-            run_config=RunConfig(
-                max_workers=int(os.getenv("EVAL_MAX_WORKERS", DEFAULT_MAX_WORKERS)),
-                timeout=int(os.getenv("EVAL_TIMEOUT", DEFAULT_EVAL_TIMEOUT)),
-            ),
-        )
-
-        # 4. 결과 집계
-        eval_results = cast(EvaluationResult, results)
-        df = eval_results.to_pandas()
-        numeric_df = df.select_dtypes(include=["number"])
-
-        # scores 처리: 모든 키와 값을 기본 타입으로 강제 변환
-        avg_scores: dict[str, float] = {}
-        raw_scores = getattr(eval_results, "scores", {})
-
-        if isinstance(raw_scores, dict):
-            for k, v in raw_scores.items():
-                avg_scores[str(k)] = float(v)
-        else:
-            # Fallback: pandas DataFrame 평균값 사용
-            mean_vals = numeric_df.mean().to_dict()
-            for k, v in mean_vals.items():
-                k_str = str(k)
-                if k_str != "latency_sec":
-                    avg_scores[k_str] = float(v)
-
-        eval_dir = EVAL_LOGS_DIR
-        eval_dir.mkdir(parents=True, exist_ok=True)
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-
-        summary_data: dict[str, Any] = {
-            "scores": avg_scores,
-            "avg_latency_sec": float(numeric_df["latency_sec"].mean()) if "latency_sec" in numeric_df.columns else 0.0,
-            "total_samples": len(df),
-            "model_name": str(model_name),
-            "timestamp": str(timestamp),
-        }
-
-        summary_path = eval_dir / f"eval_summary_{timestamp}.json"
-        with open(summary_path, "w", encoding="utf-8") as f:
-            json.dump(summary_data, f, ensure_ascii=False, indent=4)
-
-        # 상세 결과(개별 샘플 점수 및 사유) CSV 저장 추가
-        details_path = eval_dir / f"eval_details_{timestamp}.csv"
-        df.to_csv(details_path, index=False, encoding="utf-8-sig")
-
-        logger.info(f"평가 완료. 요약 저장: {summary_path}")
-        logger.info(f"상세 내역 저장: {details_path}")
-        logger.info(f"평균 응답 속도: {summary_data['avg_latency_sec']:.2f}s")
-        for m, s in avg_scores.items():
-            logger.info(f"   - {m}: {s:.4f}")
-
+        await _score_and_save(result, missing_docs=missing_docs)
     except Exception as e:
         logger.error(f"평가 실패: {e}")
 

--- a/src/eval/metrics.py
+++ b/src/eval/metrics.py
@@ -1,19 +1,4 @@
 from langchain_core.prompts import PromptTemplate
-from ragas.metrics import (
-    answer_relevancy,
-    context_precision,
-    context_recall,
-    faithfulness,
-)
-
-# 기본 평가 지표 설정
-METRICS = [
-    faithfulness,
-    answer_relevancy,
-    context_precision,
-    context_recall,
-]
-
 
 # ── [파서 벤치마크 평가 로직 보존] ──────────────────────────────────────────
 

--- a/src/tests/unit/core/test_evaluator.py
+++ b/src/tests/unit/core/test_evaluator.py
@@ -1,27 +1,22 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from ragas import EvaluationDataset
+from ragas import SingleTurnSample
 
-from src.eval.evaluator import run_rag_inference
+from src.eval.evaluator import InferenceResult, run_rag_inference
 
 
 @pytest.fixture
-def mock_db_manager():
-    with patch("src.eval.evaluator.ChromaDBManager") as mock:
-        manager_inst = mock.return_value
-        manager_inst.search.return_value = [
-            {"content": "A info", "metadata": {"src_name": "doc1", "pg_num": 1}},
-        ]
-        yield manager_inst
+def mock_retriever_factory():
+    with patch("src.eval.evaluator.RetrieverFactory") as mock:
+        mock.create_retriever.return_value = MagicMock()
+        yield mock
 
 
 @pytest.fixture
 def mock_rag_chain():
-    # run_rag_inference 내부에서 import되는 get_rag_chain을 모킹
     with patch("src.core.chains.get_rag_chain") as mock:
         chain_inst = MagicMock()
-        # 체인은 이제 generator를 반환하는 stream 메서드를 사용함
         chain_inst.stream.return_value = [
             {"stage": "generation", "status": "streaming", "output": "Test answer"},
             {
@@ -43,29 +38,41 @@ def mock_llm_factory():
         yield mock
 
 
+@pytest.fixture
+def mock_resource_snapshot():
+    with patch("src.eval.evaluator._get_resource_snapshot") as mock:
+        mock.return_value = {"cpu_percent": 10.0, "ram_mb": 1024.0}
+        yield mock
+
+
 @pytest.mark.asyncio
-async def test_run_rag_inference(mock_db_manager, mock_rag_chain, mock_llm_factory):
+async def test_run_rag_inference(mock_retriever_factory, mock_rag_chain, mock_llm_factory, mock_resource_snapshot):
     test_data = [
         {"question": "What is A?", "ground_truth": "A is alpha"},
     ]
 
-    dataset, model_name = await run_rag_inference(test_data)
+    result = await run_rag_inference(test_data)
 
-    assert isinstance(dataset, EvaluationDataset)
-    assert len(dataset) == 1
-    assert model_name == "test-model"
+    assert isinstance(result, InferenceResult)
+    assert len(result.samples) == 1
+    assert result.model_name == "test-model"
 
-    # Ragas v0.4.x EvaluationDataset은 samples 리스트를 가짐
-    sample = dataset[0]
+    sample = result.samples[0]
+    assert isinstance(sample, SingleTurnSample)
     assert sample.user_input == "What is A?"
-    assert sample.response == "Test answer"  # 출처 제거 확인
+    assert sample.response == "Test answer"
     assert "A info" in sample.retrieved_contexts
     assert sample.reference == "A is alpha"
 
+    assert len(result.latencies) == 1
+    assert len(result.resources) == 1
+    assert "cpu_percent" in result.resources[0]
+
 
 @pytest.mark.asyncio
-async def test_run_rag_inference_error_handling(mock_db_manager, mock_rag_chain, mock_llm_factory):
-    # 체인 실행 시 에러 발생 시뮬레이션
+async def test_run_rag_inference_error_handling(
+    mock_retriever_factory, mock_rag_chain, mock_llm_factory, mock_resource_snapshot
+):
     def mock_stream_error(*args, **kwargs):
         raise Exception("Chain error")
         yield {}
@@ -74,7 +81,6 @@ async def test_run_rag_inference_error_handling(mock_db_manager, mock_rag_chain,
 
     test_data = [{"question": "Error?", "ground_truth": "None"}]
 
-    dataset, _ = await run_rag_inference(test_data)
+    result = await run_rag_inference(test_data)
 
-    # 에러 발생 시 해당 샘플은 제외되어야 함
-    assert len(dataset) == 0
+    assert len(result.samples) == 0


### PR DESCRIPTION
Resolves #144

## 변경 사항 (Checklist)

* [x] 새로운 기능 추가 (feature) — Ragas 기반 평가 파이프라인(골든셋 생성·평가·지표 집계)
* [x] 리팩토링 (refactor) — 평가용 RAG 진입점 `get_rag_chain` 파라미터화, 검색 k 설정화(`RETRIEVAL_K`)
* [ ] 버그 수정 (fix)
* [ ] 문서 수정 (docs)
* [ ] 환경 설정 (setup)

## 주요 작업 내용

### 1. 평가 파이프라인 (#144 목적)
- `src/eval/dataset_generator.py`: 골든셋(질문·정답) 자동 생성
- `src/eval/evaluator.py`: Ragas 4지표(Faithfulness·Answer Relevancy·Context Precision·Recall) 평가 — judge LLM 분리, 병렬 평가, DeprecationWarning 모듈 단위 차단(전역 억제 회피)
- `src/eval/metrics.py`: 지표 집계

### 2. 평가용 RAG 진입점 정비
- `src/core/chains.py`: `get_rag_chain(llm, use_cache)` — 평가 시 생성 LLM 주입 + 시맨틱 캐시 우회(평가 격리). `RAGPipeline`에 `use_cache` 가드, 검색 k를 `settings.RETRIEVAL_K`로 설정화
- `src/common/config.py`: `RETRIEVAL_K`, `EVAL_DATA_GEN_SAMPLES`, `EVAL_MAX_WORKERS`

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**: 본 작업의 기존 브랜치(구 PR #145)가 develop의 #149 파싱 아키텍처(ParserFactory/ChunkingFactory·`layout_utils`·`text_utils`)·HWP 지원·#148 도메인 설정 외부화를 대량으로 되돌린 회귀를 포함.
* **원인 분석**: 평가 파이프라인 커밋(`f055d57`)이 #149 머지 이전 **stale base**에서 작업돼 PDF 파싱을 구버전(rawdict 하이브리드)으로 환원하고 HWP·#148을 삭제. 이후 develop을 머지해도 git 3-way가 "우리쪽 삭제 vs develop 무변경 → 삭제 유지"를 정상 적용 → **재머지로는 복원 불가**(커밋 그래프는 완전하나 트리에서 삭제가 승리).
* **해결 방안 및 의사결정**: 회귀가 파싱·청킹 아키텍처 전반에 걸쳐 선별 복원은 고위험·고비용. eval 작업이 `src/eval/` 모듈로 깔끔히 분리되는 점에 근거해 **최신 origin/develop(epic6 #142 병합 포함 — #149 파싱·HWP·#148 완비)에서 새 브랜치를 따고 eval 작업만 재적용**하는 방식을 채택, 회귀를 원천 차단.
* **결과**: develop 위에 eval 커밋 1개. `git diff origin/develop`이 eval 범위(6파일)로만 한정 — 파싱/HWP/머지 회귀 흔적 0.

## 테스트 결과 / 결과 증빙

* `ruff check`/`format` 통과
* `evaluator`/`chains` 단위 테스트 통과 — **evaluator ↔ develop RAG API 호환 입증**(`get_rag_chain`·`RetrieverFactory`·`RETRIEVAL_K`)
* `git diff origin/develop HEAD --stat` = `src/eval/*` · `core/chains.py` · `common/config.py` · `test_evaluator.py` (회귀 무관 6파일)

> 평가 지표(Ragas 4지표)는 본 파이프라인의 **실행 산출물**로 별도 측정합니다. 본 PR은 평가 도구 자체이며, 정적 린트/유닛 통과는 CI Checks에 위임합니다.

## 셀프 체크리스트

* [x] develop 브랜치 최신 반영 (origin/develop 기반 신규 분기)
* [x] 불필요한 주석/테스트용 print 제거
* [x] 관련 이슈 연결 (Resolves #144)
* [x] 기술적 도전·해결 과정(Narrative) 작성
* [ ] 직관적 결과물(지표) — 평가 도구 PR 특성상 지표는 파이프라인 실행 시 산출

## 리뷰어에게 한마디

구 **PR #145를 대체**합니다. #145는 stale base 회귀(파싱 아키텍처·HWP·#148)를 포함하고 있어, 최신 develop 위에 eval 작업만 깨끗이 재구성했습니다. 회귀 분석·재머지 불가 판정·재구성 경위는 위 Narrative를 참고해 주세요. 커밋은 머지 시 Squash 가능합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)