### PR TITLE
refactor: CPU docker 빌드 분기 제거 및 GPU 전용 최적화 (#167)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,5 @@ jobs:
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY || 'rag-chatbot-app' }}:latest
             ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY || 'rag-chatbot-app' }}:${{ github.sha }}
-          build-args: |
-            DEVICE_TYPE=gpu
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,6 @@ RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 # 의존성 파일 복사 및 설치 (GPU 맞춤 설정 사용, 캐시 마운트로 초고속화)
 COPY requirements-prod.txt .
 RUN --mount=type=cache,target=/root/.cache/pip \
-    sed -i 's/+cpu//g' requirements-prod.txt && \
-    sed -i 's|whl/cpu|whl/cu130|g' requirements-prod.txt && \
     pip install -r requirements-prod.txt
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,19 +18,12 @@ ENV PATH="/opt/venv/bin:$PATH"
 # pip 업그레이드
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 
-# ARG를 통해 CPU / GPU 모드 선택 (기본값은 gpu)
-ARG DEVICE_TYPE=gpu
-
-# 의존성 파일 복사 및 설치 (CPU 및 GPU 맞춤 설정 사용, 캐시 마운트로 초고속화)
+# 의존성 파일 복사 및 설치 (GPU 맞춤 설정 사용, 캐시 마운트로 초고속화)
 COPY requirements-prod.txt .
 RUN --mount=type=cache,target=/root/.cache/pip \
-    if [ "$DEVICE_TYPE" = "gpu" ]; then \
-        sed -i 's/+cpu//g' requirements-prod.txt && \
-        sed -i 's|whl/cpu|whl/cu130|g' requirements-prod.txt && \
-        pip install -r requirements-prod.txt; \
-    else \
-        pip install -r requirements-prod.txt; \
-    fi
+    sed -i 's/+cpu//g' requirements-prod.txt && \
+    sed -i 's|whl/cpu|whl/cu130|g' requirements-prod.txt && \
+    pip install -r requirements-prod.txt
 
 
 # --- Stage 2: Final Runtime ---

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ AI 추론 및 리랭킹 연산의 성능을 극대화하기 위해 배포 서버
 * **실행 명령어**:
   ```bash
   # 기본 서비스와 GPU 예약 구성을 결합하여 CUDA 가속 버전으로 기동
-  docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --build
+  docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
   ```
 
 ### 2. 로컬 개발 환경 (macOS / Windows / Non-NVIDIA)

--- a/README.md
+++ b/README.md
@@ -59,40 +59,41 @@
 
 ---
 
-## Docker 환경에서 시작하기 (Docker Setup)
+## 실행 및 개발 환경 가이드 (Setup & Execution Guide)
 
-팀원 간 라이브러리 버전 충돌을 방지하고, ChromaDB 서버를 안정적으로 운영하기 위해 Docker 환경 사용을 권장합니다.
+AI 추론 및 리랭킹 연산의 성능을 극대화하기 위해 배포 서버는 NVIDIA GPU(CUDA) 가속 기반의 Docker 환경으로 완전히 단일화하여 운영합니다. 이에 따라 로컬 개발 환경(Mac 및 AMD GPU PC 등)에서는 아래 가이드에 맞추어 하드웨어 가속을 최대한 활용할 수 있도록 이원화하여 구동할 것을 권장합니다.
 
-### 1. 필수 요구사항
-- [Docker Desktop](https://www.docker.com/products/docker-desktop/) 설치
-- (Windows/Linux GPU 사용 시) [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) 설치
-
-### 2. 실행 방법
-본인의 하드웨어 환경(CPU 또는 GPU)에 맞는 명령어를 입력하세요.
-
-* **CPU 전용 환경:**
+### 1. 배포 및 서버 환경 (Docker + NVIDIA GPU)
+* **대상**: AWS EC2 등 NVIDIA GPU 하드웨어가 장착된 서버 환경
+* **특징**: 컨테이너 빌드 및 구동 시 CUDA 가속 환경을 강제 전제하여 빌드됩니다.
+* **실행 명령어**:
   ```bash
-  # 컨테이너 빌드 및 실행 (기본 CPU 모드)
-  docker-compose up -d --build
+  # 기본 서비스와 GPU 예약 구성을 결합하여 CUDA 가속 버전으로 기동
+  docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --build
   ```
 
-* **GPU 환경 (NVIDIA 외장 그래픽 활용 시):**
-  > [!IMPORTANT]
-  > GPU 가속을 사용하기 전, 호스트 시스템에 **NVIDIA Container Toolkit**이 정상적으로 설치되고 Docker 설정에 등록되어 있어야 합니다.
-  
+### 2. 로컬 개발 환경 (macOS / Windows / Non-NVIDIA)
+Apple Silicon(M 시리즈) 및 AMD GPU 환경에서는 가상화 레이어의 제약으로 인해 컨테이너 내 GPU 포트포워딩이 지원되지 않거나 복잡합니다. 따라서 무거운 AI 연산(Ollama, PyTorch)은 로컬 호스트 네이티브로 실행하고, DB류만 Docker로 격리 기동하는 방식을 권장합니다.
+
+* **단계 A: 공통 인프라 기동 (Docker)**
   ```bash
-  # 기본 서비스에 GPU 설정을 병합하여 CUDA 가속 버전으로 빌드 및 실행
-  docker-compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --build
+  # ChromaDB, Redis 등 데이터 스토어만 백그라운드로 기동
+  docker compose up -d chromadb redis
   ```
 
-### 3. 서비스 접속
-- **Streamlit UI:** `http://localhost:8501`
-- **ChromaDB 상태 확인:** `http://localhost:8000/api/v2/heartbeat` (숫자가 표시되면 정상)
+* **단계 B: 로컬 AI 엔진 및 앱 기동 (Host Native)**
+  1. **Ollama**:
+     - 각 OS에 맞는 [Ollama Desktop](https://ollama.com)을 직접 설치 및 백그라운드 실행합니다. (Mac의 Apple GPU/NPU 가속, Windows/Linux의 AMD 가속을 자동 감지하여 최고 속도로 가동합니다.)
+  2. **Python Application**:
+     - 로컬 터미널 가상환경에서 Streamlit을 직접 가동합니다. PyTorch가 호스트의 MPS(Mac) 가속기를 자동 포착하여 임베딩 및 리랭커 연산 속도를 가속합니다.
+     ```bash
+     pip install -r requirements.txt
+     streamlit run src/app.py
+     ```
 
-### 4. 주요 명령어
-- **로그 확인:** `docker-compose logs -f app`
-- **컨테이너 중지:** `docker-compose down`
-- **컨테이너 내 명령어 실행:** `docker-compose exec app bash`
+### 3. 서비스 접속 정보
+* **Streamlit UI (로컬 기동 시)**: `http://localhost:8501`
+* **ChromaDB 상태 확인**: `http://localhost:8000/api/v2/heartbeat` (정상 작동 시 숫자가 반환됨)
 
 ---
 

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -1,8 +1,5 @@
 services:
   app:
-    build:
-      context: .
-      dockerfile: Dockerfile
     deploy:
       resources:
         reservations:

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -3,8 +3,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        - DEVICE_TYPE=gpu
     deploy:
       resources:
         reservations:

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,5 +1,5 @@
-# [Pytorch CPU 전용 인덱스]
---extra-index-url https://download.pytorch.org/whl/cpu
+# [Pytorch NVIDIA GPU 전용 인덱스]
+--extra-index-url https://download.pytorch.org/whl/cu130
 
 # 핵심 프레임워크 (2026년 최신 안정 버전)
 langchain==1.2.18
@@ -17,10 +17,10 @@ langchain-huggingface==1.2.2
 openai==2.36.0
 langchain-openai==1.2.1
 
-# 딥러닝 및 문장 임베딩 (CPU 환경 전용)
-torch==2.11.0+cpu
-torchvision==0.26.0+cpu
-torchaudio==2.11.0+cpu
+# 딥러닝 및 문장 임베딩 (NVIDIA GPU 환경 전용)
+torch==2.11.0+cu130
+torchvision==0.26.0+cu130
+torchaudio==2.11.0+cu130
 sentence-transformers==5.4.1
 transformers==5.8.0
 accelerate==1.13.0

--- a/scripts/ec2-startup.sh
+++ b/scripts/ec2-startup.sh
@@ -31,8 +31,11 @@ fi
 
 cd "$APP_DIR"
 
-echo "Pre-cleaning dangling/unused docker resources to free up space..."
-docker image prune -f
+echo "Stopping existing containers to release image layers..."
+docker compose -f docker-compose.yml -f docker-compose.gpu.yml down
+
+echo "Aggressively cleaning up old/dangling docker resources to free up space..."
+docker system prune -a -f
 
 echo "Pulling latest Docker images..."
 docker compose -f docker-compose.yml -f docker-compose.gpu.yml pull

--- a/scripts/ec2-startup.sh
+++ b/scripts/ec2-startup.sh
@@ -31,6 +31,9 @@ fi
 
 cd "$APP_DIR"
 
+echo "Pre-cleaning dangling/unused docker resources to free up space..."
+docker image prune -f
+
 echo "Pulling latest Docker images..."
 docker compose -f docker-compose.yml -f docker-compose.gpu.yml pull
 

--- a/scripts/ec2-startup.sh
+++ b/scripts/ec2-startup.sh
@@ -31,19 +31,17 @@ fi
 
 cd "$APP_DIR"
 
-echo "Stopping existing containers to release image layers..."
-docker compose -f docker-compose.yml -f docker-compose.gpu.yml down
+echo "Stopping and removing the old app container to release locks on layers..."
+docker compose -f docker-compose.yml -f docker-compose.gpu.yml stop app
+docker compose -f docker-compose.yml -f docker-compose.gpu.yml rm -f app
 
-echo "Aggressively cleaning up old/dangling docker resources to free up space..."
-docker system prune -a -f
+echo "Cleaning up the old app image to free up disk space (preserving active DB images)..."
+docker image prune -af
 
-echo "Pulling latest Docker images..."
-docker compose -f docker-compose.yml -f docker-compose.gpu.yml pull
+echo "Pulling the latest App image from ECR..."
+docker compose -f docker-compose.yml -f docker-compose.gpu.yml pull app
 
 echo "Starting containers..."
 docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
-
-echo "Cleaning up old/dangling docker images to optimize disk space..."
-docker image prune -f
 
 echo "Deployment completed successfully!"


### PR DESCRIPTION
Resolves #167

### 1. 목적
* 배포용 Docker 컨테이너 환경을 NVIDIA GPU(CUDA) 가속 모델 단일 타겟으로 완전히 전제화함에 따라, 기존의 CPU 구동을 위한 조건 분기 로직 및 레거시 문서를 전면 삭제함.
* 컨테이너 빌드 및 CI/CD 설정을 최적화하여 복잡도를 낮추고, 로컬 개발 환경은 기기 본연의 GPU 성능(macOS MPS 등)을 사용할 수 있는 호스트 네이티브 개발 구조로 통일함.

### 2. 주요 작업 내용
* **Dockerfile 내 CPU/GPU 빌드 조건문 제거 및 CUDA 휠 최적화**:
  - DEVICE_TYPE ARG 설정 및 if [ "$DEVICE_TYPE" = "gpu" ] 조건문을 삭제하여 GPU 빌드 단일 경로로 최적화했습니다.
  - 최신 그래픽 드라이버(NVIDIA 580) 환경 정합성에 맞춰 PyTorch 휠 버전은 고성능 CUDA 13.0(cu130) 규격으로 유지 고정하였습니다.
* **배포 파이프라인 최적화**:
  - .github/workflows/deploy.yml 파일에서 불필요해진 build-args (DEVICE_TYPE=gpu) 설정을 제거했습니다.
  - docker-compose.gpu.yml에서 더 이상 사용하지 않는 빌드 매개변수(args) 블록을 삭제했습니다.
  - 배포 중 불필요한 빌드 프로세스가 개입하지 못하게 `docker-compose.gpu.yml`에서 `build` 속성을 전면 제거하였습니다.
* **가이드 개편 (README.md)**:
  - README.md 내 컨테이너 내부 CPU 구동 명령어 기술을 완전히 소거했습니다.
  - 로컬 환경(맥북/Non-NVIDIA 등)은 DB만 도커로 격리 기동하고 앱과 Ollama는 로컬 호스트 네이티브에서 기기 가속(MPS 등)을 적용해 실행하도록 개발자 환경 이원화 가이드를 명확히 명세화했습니다.

### 3. 기술적 도전 및 해결 과정 (Technical Narrative)
* **드라이버 버전 정합성에 따른 의사결정**:
  - 초기 계획에서는 PyTorch 버전을 cu124로 낮추려고 했으나, 이미 운영용 AWS EC2 인스턴스의 드라이버가 CUDA 13.0을 네이티브 지원하는 최신 버전(NVIDIA 580)으로 업그레이드 완료된 상태였습니다.
  - 이에 따라 불필요한 하향 패키징 대신, 고성능 cu130 패키지를 고정 수립하여 이미지 리빌드 시에도 최적의 가속 효율을 유지하도록 구조를 고착화했습니다.
* **CD 배포 과정에서의 디스크 임시 한도 초과 해결**:
  - 50GB 루트 볼륨 환경에서 GPU 이미지 pull 시 일시적으로 이전 이미지와 중첩 공존하면서 디스크 부족 현상(no space left on device)이 발생했습니다.
  - 이를 예방하기 위해 `ec2-startup.sh` 배포 스크립트에서 새 이미지를 pull하기 전에 기존 컨테이너를 중지하고 미사용 Docker 리소스를 강제 정리(`docker system prune -a -f`)하도록 조치하여 사전에 충분한 용량(약 30GB 이상)을 비워두는 안정성을 확보했습니다.

### 4. 테스트 결과 증빙
* [x] GitHub Actions 이미지 빌드 및 ECR 푸시 성공 (Run 26930154525)
* [x] EC2 인스턴스 배포 및 nvidia-smi/docker logs를 통한 GPU 가속 매핑 최종 검증 완료

* **실제 가동 중인 컨테이너 상태 (`docker ps`)**:
  ```
  CONTAINER ID   IMAGE                                                                      COMMAND                  CREATED         STATUS                   PORTS                                                   NAMES
  535b9961e37f   270278216520.dkr.ecr.ap-northeast-2.amazonaws.com/rag-chatbot-app:latest   "streamlit run src/a…"   3 minutes ago   Up 3 minutes (healthy)   0.0.0.0:8501->8501/tcp, [::]:8501->8501/tcp, 9090/tcp   rag-chatbot-app
  14fdde753d35   ollama/ollama:latest                                                       "/bin/bash /root/oll…"   4 minutes ago   Up 3 minutes             0.0.0.0:11434->11434/tcp, [::]:11434->11434/tcp         rag-chatbot-ollama
  d4d7d4939c4c   redis:7-alpine                                                             "docker-entrypoint.s…"   4 minutes ago   Up 3 minutes (healthy)   6379/tcp                                                rag-chatbot-redis
  f54680084eaf   chromadb/chroma:latest                                                     "dumb-init -- chroma…"   4 minutes ago   Up 3 minutes (healthy)   0.0.0.0:8000->8000/tcp, [::]:8000->8000/tcp             rag-chatbot-chromadb
  ```

* **NVIDIA 드라이버 및 CUDA 버전 확인 (`nvidia-smi`)**:
  ```
  NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0
  GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC
  0  Tesla T4                       Off | 00000000:00:1E.0 Off |                    0
  ```

* **Ollama 컨테이너 내 CUDA 가속 정상 활성화 로깅**:
  ```
  time=2026-06-04T05:02:37.718Z level=INFO source=types.go:32 msg="inference compute" id=0 filter_id=0 library=CUDA compute=7.5 name=CUDA0 description="Tesla T4" libdirs=ollama,cuda_v13 driver=13.0 pci_id=0000:00:1e.0 type=discrete total="14.6 GiB" available="14.5 GiB"
  ```

* **배포 완료 후 디스크 용량 상태 (`df -h`)**:
  ```
  Filesystem       Size  Used Avail Use% Mounted on
  /dev/root         49G   34G   15G  70% /
  ```

### 5. 셀프 체크리스트
* [x] 코드가 프로젝트의 스타일 가이드를 준수합니다.
* [x] 완료 조건(DoD)을 모두 충족했습니다.
* [x] 로컬 환경에서 충분히 테스트를 진행했습니다.
* [x] 불필요한 임시 파일이나 더미 코드가 포함되지 않았습니다.
* [x] PR 본문을 프로젝트 양식에 맞게 작성했습니다.
