### PR TITLE
refactor(eval): 평가 요약(eval_summary)에 추론 파라미터 기록 (#173)

### DIFF
--- a/src/eval/evaluator.py
+++ b/src/eval/evaluator.py
@@ -112,6 +112,25 @@ def _get_system_info() -> dict[str, Any]:
     return info
 
 
+def _get_inference_settings() -> dict[str, Any]:
+    """생성 LLM의 추론(생성) 파라미터를 기록용으로 수집한다.
+
+    지표가 어떤 설정으로 산출됐는지 요약(eval_summary)만으로 역추적하기 위함이다.
+    ollama 백엔드일 때만 ollama 전용 파라미터를 포함하고, 그 외(gemini/claude)는
+    공통 항목(temperature)만 기록해 의미 없는 키가 끼지 않게 한다.
+    """
+    info: dict[str, Any] = {"temperature": settings.TEMPERATURE}
+    if settings.MODEL_TYPE == "ollama":
+        info |= {
+            "num_predict": settings.OLLAMA_NUM_PREDICT,
+            "num_ctx": settings.OLLAMA_NUM_CTX,
+            "repeat_penalty": settings.OLLAMA_REPEAT_PENALTY,
+            "keep_alive": settings.OLLAMA_KEEP_ALIVE,
+            "think": settings.OLLAMA_THINK,
+        }
+    return info
+
+
 def _get_indexed_documents() -> list[str]:
     try:
         paths = sorted([f for f in PROCESSED_DATA_DIR.glob("*.json") if f.name != "manifest.json"])
@@ -322,6 +341,7 @@ async def _score_and_save(result: InferenceResult, missing_docs: list[str] | Non
             "reranker": (
                 f"{settings.RERANKER_TYPE}/{settings.RERANKER_MODEL_NAME} (top_k={settings.RERANKER_MAX_DOCS})"
             ),
+            "inference": _get_inference_settings(),
         },
         "judge": {
             "llm": f"{settings.EVAL_JUDGE_TYPE}/{settings.EVAL_JUDGE_MODEL}",

--- a/src/tests/unit/core/test_evaluator.py
+++ b/src/tests/unit/core/test_evaluator.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from ragas import SingleTurnSample
 
-from src.eval.evaluator import InferenceResult, run_rag_inference
+from src.eval.evaluator import InferenceResult, _get_inference_settings, run_rag_inference
 
 
 @pytest.fixture
@@ -84,3 +84,28 @@ async def test_run_rag_inference_error_handling(
     result = await run_rag_inference(test_data)
 
     assert len(result.samples) == 0
+
+
+def test_inference_settings_ollama_includes_ollama_params(monkeypatch):
+    """ollama 백엔드면 공통(temperature) + ollama 전용 추론 파라미터를 모두 기록한다."""
+    monkeypatch.setattr("src.eval.evaluator.settings.MODEL_TYPE", "ollama")
+    monkeypatch.setattr("src.eval.evaluator.settings.OLLAMA_NUM_PREDICT", 2048)
+    monkeypatch.setattr("src.eval.evaluator.settings.OLLAMA_REPEAT_PENALTY", 1.1)
+
+    info = _get_inference_settings()
+
+    assert "temperature" in info
+    assert info["num_predict"] == 2048
+    assert info["repeat_penalty"] == 1.1
+    assert {"num_ctx", "keep_alive", "think"} <= info.keys()
+
+
+def test_inference_settings_non_ollama_only_common(monkeypatch):
+    """비-ollama(gemini/claude) 백엔드면 ollama 전용 키 없이 공통 항목만 기록한다."""
+    monkeypatch.setattr("src.eval.evaluator.settings.MODEL_TYPE", "claude")
+
+    info = _get_inference_settings()
+
+    assert "temperature" in info
+    assert "num_predict" not in info
+    assert all(not k.startswith(("num_", "repeat_", "keep_", "think")) for k in info)


### PR DESCRIPTION
Resolves #173

## 변경 사항 (Checklist)

* [x] 리팩토링 (refactor) — 평가 요약(eval_summary)에 추론 파라미터 기록

## 주요 작업 내용

- `src/eval/evaluator.py`: `summary_data["pipeline"]`에 `inference` 블록 추가.
  - 공통: `temperature`
  - ollama 백엔드: `num_predict` / `num_ctx` / `repeat_penalty` / `keep_alive` / `think`
  - `MODEL_TYPE != "ollama"`이면 ollama 전용 키 생략(공통 항목만)
- 추론 파라미터 수집을 `_get_inference_settings()` 헬퍼로 분리(테스트 가능 seam).
- 헬퍼는 effective settings(env > .env > default)를 읽어 **실제 사용값**을 기록한다.

## 배경

#170에서 `OLLAMA_NUM_PREDICT`(2048)·`OLLAMA_REPEAT_PENALTY`(1.1) 등을 튜닝했으나, 결과 요약에 어떤 추론 설정으로 측정했는지 남지 않아 지표만으로는 역추적이 불가했다. 모델명은 이미 `pipeline.llm`(예: `ollama/gemma4:e4b`)에 기록되므로, 본 PR은 생성 파라미터 누락만 보완한다. (#170 리뷰 코멘트 후속)

## 테스트 결과 / 결과 증빙

- `_get_inference_settings` 단위 테스트 2종 추가(ollama 전용 키 포함 / 비-ollama 공통만).
- evaluator 단위 테스트 4건 통과, ruff check + format 통과.
- 실제 출력 예시(`MODEL_TYPE=ollama`):

```json
{"temperature": 0.1, "num_predict": 2048, "num_ctx": 8192, "repeat_penalty": 1.1, "keep_alive": -1, "think": false}
```

## 범위

요약 기록 항목 추가에 한정. 추론 파라미터 자체의 튜닝/변경은 없음. summary JSON의 다른 블록(retriever/reranker/judge/system)은 변경 없음.

## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영했나요? (브랜치 base develop)
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
* [x] 관련 이슈 번호를 연결했나요? (Resolves #173)
* [x] 결과 증빙(테스트·출력 예시)을 첨부했나요?

Generated with Claude Code (https://claude.com/claude-code)
