### PR TITLE
refactor(cache): 시맨틱 캐시 전역 토글 추가 (폐기 대신 기본 비활성) (#157)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -265,6 +265,15 @@ with st.sidebar:
     # 4. 기타 설정
     st.toggle("상세 추론 과정 보기", key="show_expert_mode", disabled=st.session_state.is_generating)
 
+    # 시맨틱 캐시 런타임 토글: 전역 settings에 즉시 반영해 재기동 없이 on/off (#157).
+    # settings는 프로세스 전역 단일 객체 — 내부 관리자 운영 도구 전제이므로 세션 간 공유를 수용한다.
+    settings.SEMANTIC_CACHE_ENABLED = st.toggle(
+        "시맨틱 캐시 활성화",
+        value=settings.SEMANTIC_CACHE_ENABLED,
+        disabled=st.session_state.is_generating,
+        help="질의 유사도 기반 캐시. 미세한 질의 차이를 못 가르는 오탐 위험이 있어 기본 비활성입니다.",
+    )
+
     # API 토큰 사용량 및 실시간 과금 추적
     session_tokens = st.session_state.get("session_tokens", {"input": 0, "output": 0, "cost_usd": 0.0})
     if session_tokens["input"] > 0 or session_tokens["output"] > 0:

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -132,6 +132,10 @@ class Settings(BaseSettings):
     CI: bool = False
 
     # 7. 시맨틱 캐시 설정
+    # 기본 비활성(opt-in): 질의 유사도만으로 캐시 히트를 판정해 "2020년"과 "2021년"처럼 미세하지만
+    # 결정적인 차이를 못 가르고 과거 오답을 그대로 반환하는 False Positive 리스크가 있다. 코드는 보존하되
+    # 명시적으로 켤 때만(SEMANTIC_CACHE_ENABLED=true) 동작한다. (#157)
+    SEMANTIC_CACHE_ENABLED: bool = Field(default=False)
     SEMANTIC_CACHE_COLLECTION_NAME: str = Field(default="semantic_cache")
     SEMANTIC_CACHE_THRESHOLD: float = Field(default=0.95)
     MAX_CHAT_HISTORY_TURNS: int = Field(default=5)

--- a/src/core/chains.py
+++ b/src/core/chains.py
@@ -54,7 +54,8 @@ class RAGPipeline:
         self.llm = llm or LLMFactory.create_llm_with_fallback()
         self.reranker = reranker or RerankerFactory.create()
         self.tracing_logger = TracingLogger()
-        self.cache = SemanticCache() if use_cache else None
+        # 전역 토글이 마스터 스위치: 기본 비활성이며, use_cache 인자(예: 평가는 False)와 AND로 결합한다. (#157)
+        self.cache = SemanticCache() if (use_cache and settings.SEMANTIC_CACHE_ENABLED) else None
 
     def _resolve_parent_documents(self, docs: list[Document]) -> list[Document]:
         """자식 청크로 검색된 문서들을 부모 청크의 원문으로 전환하며, 동일 부모 및 동일 텍스트 중복을 제거합니다."""

--- a/src/core/chains.py
+++ b/src/core/chains.py
@@ -54,8 +54,22 @@ class RAGPipeline:
         self.llm = llm or LLMFactory.create_llm_with_fallback()
         self.reranker = reranker or RerankerFactory.create()
         self.tracing_logger = TracingLogger()
-        # 전역 토글이 마스터 스위치: 기본 비활성이며, use_cache 인자(예: 평가는 False)와 AND로 결합한다. (#157)
-        self.cache = SemanticCache() if (use_cache and settings.SEMANTIC_CACHE_ENABLED) else None
+        # 시맨틱 캐시는 런타임 토글을 위해 lazy 생성한다: @st.cache_resource로 파이프라인이 싱글톤 공유되므로
+        # 생성자 시점에 플래그를 굳히면 재기동해야 반영된다. 대신 _get_cache()가 호출 시점에 판별한다.
+        # 기본 OFF면 객체조차 만들지 않아 idle 비용이 0이고, use_cache=False(평가)는 영구 비활성. (#157)
+        self._use_cache = use_cache
+        self._cache: SemanticCache | None = None
+        self._cache_lock = threading.Lock()
+
+    def _get_cache(self) -> SemanticCache | None:
+        """런타임 시점에 전역 토글을 확인해 캐시를 반환한다(켜진 경우에만 최초 1회 lazy 생성 후 메모이즈)."""
+        if not (self._use_cache and settings.SEMANTIC_CACHE_ENABLED):
+            return None
+        if self._cache is None:
+            with self._cache_lock:
+                if self._cache is None:  # 동시 최초 진입 시 이중 생성 방지
+                    self._cache = SemanticCache()
+        return self._cache
 
     def _resolve_parent_documents(self, docs: list[Document]) -> list[Document]:
         """자식 청크로 검색된 문서들을 부모 청크의 원문으로 전환하며, 동일 부모 및 동일 텍스트 중복을 제거합니다."""
@@ -292,9 +306,10 @@ class RAGPipeline:
         history = input_dict.get("history", [])
 
         with self.tracing_logger.start_session(query=query) as session:
-            # 1. Semantic Cache Check
+            # 1. Semantic Cache Check — 런타임 토글을 한 번 평가해 조회/적재에 일관되게 쓴다. (#157)
+            cache = self._get_cache()
             yield {"stage": "cache", "status": "running"}
-            cached_result = self.cache.get(query) if self.cache else None
+            cached_result = cache.get(query) if cache else None
             if cached_result:
                 session.data["cache_hit"] = True
                 yield {"stage": "cache", "status": "hit"}
@@ -344,8 +359,8 @@ class RAGPipeline:
                 for doc in final_docs
             ]
 
-            if self.cache:
-                self.cache.add(query, full_answer, docs_for_cache)
+            if cache:
+                cache.add(query, full_answer, docs_for_cache)
 
             yield {"stage": "citation", "status": "complete", "output": citations_str, "source_documents": final_docs}
 

--- a/src/pipeline/orchestrator.py
+++ b/src/pipeline/orchestrator.py
@@ -44,9 +44,25 @@ class PipelineOrchestrator:
             self.ingestion_pipeline = IngestionPipeline(self.strategy, storage_manager=self.storage_manager)
             self.manifest_manager = ManifestManager(self.parser_type)
             self.tracing_logger = TracingLogger()
-            self.cache = SemanticCache() if settings.SEMANTIC_CACHE_ENABLED else None  # 기본 비활성 (#157)
+            # 시맨틱 캐시는 런타임 토글을 위해 lazy 생성한다(_get_cache). 오케스트레이터도 싱글톤이라
+            # 생성자에서 굳히면 재기동해야 반영된다. 기본 OFF면 미생성(idle 0). (#157)
+            self._cache = None
+            self._cache_lock = threading.Lock()
             self._initialized = True
             logger.info("PipelineOrchestrator 초기화 완료.")
+
+    def _get_cache(self) -> SemanticCache | None:
+        """런타임 시점에 전역 토글을 확인해 캐시를 반환한다(켜진 경우에만 최초 1회 lazy 생성 후 메모이즈).
+
+        켜진 상태로 색인이 일어나면 stale 캐시를 flush해야 하므로 이 접근자를 거쳐 캐시를 확보한다.
+        """
+        if not settings.SEMANTIC_CACHE_ENABLED:
+            return None
+        if self._cache is None:
+            with self._cache_lock:
+                if self._cache is None:  # 동시 최초 진입 시 이중 생성 방지
+                    self._cache = SemanticCache()
+        return self._cache
 
     def _get_parser_strategy(self) -> ParserStrategy:
         """설정된 파서 타입에 따라 전략을 반환하며 가용성을 검증합니다."""
@@ -133,10 +149,11 @@ class PipelineOrchestrator:
     ):
         has_changes = bool(files_to_process or source_ids_to_delete or relative_paths_to_delete)
 
-        if has_changes and self.cache:
+        cache = self._get_cache()
+        if has_changes and cache:
             with session.trace_step("cache_flush"):
                 logger.info("데이터 변경이 감지되어 시맨틱 캐시를 초기화합니다.")
-                self.cache.flush()
+                cache.flush()
 
         if source_ids_to_delete or relative_paths_to_delete:
             self._cleanup_db(session, source_ids_to_delete, relative_paths_to_delete)

--- a/src/pipeline/orchestrator.py
+++ b/src/pipeline/orchestrator.py
@@ -44,7 +44,7 @@ class PipelineOrchestrator:
             self.ingestion_pipeline = IngestionPipeline(self.strategy, storage_manager=self.storage_manager)
             self.manifest_manager = ManifestManager(self.parser_type)
             self.tracing_logger = TracingLogger()
-            self.cache = SemanticCache()
+            self.cache = SemanticCache() if settings.SEMANTIC_CACHE_ENABLED else None  # 기본 비활성 (#157)
             self._initialized = True
             logger.info("PipelineOrchestrator 초기화 완료.")
 
@@ -133,7 +133,7 @@ class PipelineOrchestrator:
     ):
         has_changes = bool(files_to_process or source_ids_to_delete or relative_paths_to_delete)
 
-        if has_changes:
+        if has_changes and self.cache:
             with session.trace_step("cache_flush"):
                 logger.info("데이터 변경이 감지되어 시맨틱 캐시를 초기화합니다.")
                 self.cache.flush()

--- a/src/tests/unit/core/test_cache_toggle.py
+++ b/src/tests/unit/core/test_cache_toggle.py
@@ -1,7 +1,8 @@
-"""시맨틱 캐시 전역 토글(SEMANTIC_CACHE_ENABLED) 게이트 단위 테스트. (이슈 #157)
+"""시맨틱 캐시 런타임 토글(SEMANTIC_CACHE_ENABLED) 게이트 단위 테스트. (이슈 #157)
 
-캐시 코드는 보존하되 기본 비활성(opt-in)이며, 켤 때만 생성된다. RAGPipeline·PipelineOrchestrator
-두 생성 지점이 플래그로 게이트되는지, 끈 상태에서 flush가 no-op인지 검증한다.
+캐시 코드는 보존하되 기본 비활성(opt-in)이고, @st.cache_resource로 파이프라인/오케스트레이터가
+싱글톤 공유되므로 재기동 없이 런타임에 on/off되어야 한다. 따라서 생성자 시점이 아닌 호출 시점
+(_get_cache)에 플래그를 판별하고, 켜진 경우에만 최초 1회 lazy 생성 후 메모이즈한다(기본 OFF면 idle 0).
 """
 
 from unittest.mock import MagicMock, patch
@@ -16,25 +17,28 @@ def _make_pipeline(use_cache: bool = True) -> RAGPipeline:
 
 class TestChainsCacheToggle:
     def test_cache_off_by_default(self):
-        """기본(플래그 False)에서는 use_cache=True여도 캐시를 만들지 않는다."""
+        """기본(플래그 False)이면 호출해도 캐시를 만들지 않는다(lazy, idle 0)."""
         with (
             patch("src.core.chains.SemanticCache") as mock_cache,
             patch("src.core.chains.TracingLogger"),
             patch("src.core.chains.settings.SEMANTIC_CACHE_ENABLED", False),
         ):
             pipeline = _make_pipeline()
-            assert pipeline.cache is None
+            assert pipeline._get_cache() is None
             mock_cache.assert_not_called()
 
-    def test_cache_on_when_enabled(self):
-        """플래그를 켜고 use_cache=True면 캐시가 생성된다."""
+    def test_cache_lazy_built_when_enabled(self):
+        """플래그 ON이면 첫 호출에 lazy 생성되고 이후 메모이즈된다(생성은 단 한 번)."""
         with (
             patch("src.core.chains.SemanticCache") as mock_cache,
             patch("src.core.chains.TracingLogger"),
             patch("src.core.chains.settings.SEMANTIC_CACHE_ENABLED", True),
         ):
             pipeline = _make_pipeline()
-            assert pipeline.cache is mock_cache.return_value
+            first = pipeline._get_cache()
+            second = pipeline._get_cache()
+            assert first is mock_cache.return_value
+            assert first is second
             mock_cache.assert_called_once()
 
     def test_use_cache_false_overrides_enabled(self):
@@ -45,30 +49,59 @@ class TestChainsCacheToggle:
             patch("src.core.chains.settings.SEMANTIC_CACHE_ENABLED", True),
         ):
             pipeline = _make_pipeline(use_cache=False)
-            assert pipeline.cache is None
+            assert pipeline._get_cache() is None
             mock_cache.assert_not_called()
+
+    def test_runtime_toggle_without_rebuild(self):
+        """싱글톤 인스턴스 재생성 없이 런타임 플래그 변화만으로 on/off되고, 생성은 1회뿐이다."""
+        with (
+            patch("src.core.chains.SemanticCache") as mock_cache,
+            patch("src.core.chains.TracingLogger"),
+            patch("src.core.chains.settings") as mock_settings,
+        ):
+            mock_settings.SEMANTIC_CACHE_ENABLED = False
+            pipeline = _make_pipeline()
+            assert pipeline._get_cache() is None  # OFF: 미생성
+
+            mock_settings.SEMANTIC_CACHE_ENABLED = True
+            assert pipeline._get_cache() is mock_cache.return_value  # 재기동 없이 ON
+
+            mock_settings.SEMANTIC_CACHE_ENABLED = False
+            assert pipeline._get_cache() is None  # 다시 OFF면 미반환
+
+            mock_cache.assert_called_once()  # 생성은 단 한 번
 
 
 class TestOrchestratorCacheToggle:
-    def _build(self, enabled: bool) -> PipelineOrchestrator:
+    def setup_method(self):
         PipelineOrchestrator._instance = None
-        with (
+
+    def teardown_method(self):
+        PipelineOrchestrator._instance = None
+
+    def _patches(self, enabled: bool):
+        return (
             patch("src.pipeline.orchestrator.IngestionPipeline"),
             patch("src.pipeline.orchestrator.StorageManager"),
-            patch("src.pipeline.orchestrator.SemanticCache") as mock_cache,
+            patch("src.pipeline.orchestrator.SemanticCache"),
             patch("src.pipeline.orchestrator.settings.SEMANTIC_CACHE_ENABLED", enabled),
-        ):
-            orch = PipelineOrchestrator()
-            return orch, mock_cache
+        )
 
     def test_cache_off_by_default(self):
-        """기본(플래그 False)에서는 오케스트레이터가 캐시를 만들지 않는다."""
-        orch, mock_cache = self._build(enabled=False)
-        assert orch.cache is None
-        mock_cache.assert_not_called()
+        """기본(플래그 False)에서는 호출해도 캐시를 만들지 않는다."""
+        ingestion, storage, mock_cache, flag = self._patches(enabled=False)
+        with ingestion, storage, mock_cache as cache_cls, flag:
+            orch = PipelineOrchestrator()
+            assert orch._get_cache() is None
+            cache_cls.assert_not_called()
 
-    def test_cache_on_when_enabled(self):
-        """플래그를 켜면 오케스트레이터가 캐시를 생성한다."""
-        orch, mock_cache = self._build(enabled=True)
-        assert orch.cache is mock_cache.return_value
-        mock_cache.assert_called_once()
+    def test_cache_lazy_built_when_enabled(self):
+        """플래그 ON이면 호출 시 lazy 생성되고 이후 메모이즈된다(생성은 단 한 번)."""
+        ingestion, storage, mock_cache, flag = self._patches(enabled=True)
+        with ingestion, storage, mock_cache as cache_cls, flag:
+            orch = PipelineOrchestrator()
+            first = orch._get_cache()
+            second = orch._get_cache()
+            assert first is cache_cls.return_value
+            assert first is second
+            cache_cls.assert_called_once()

--- a/src/tests/unit/core/test_cache_toggle.py
+++ b/src/tests/unit/core/test_cache_toggle.py
@@ -1,0 +1,74 @@
+"""시맨틱 캐시 전역 토글(SEMANTIC_CACHE_ENABLED) 게이트 단위 테스트. (이슈 #157)
+
+캐시 코드는 보존하되 기본 비활성(opt-in)이며, 켤 때만 생성된다. RAGPipeline·PipelineOrchestrator
+두 생성 지점이 플래그로 게이트되는지, 끈 상태에서 flush가 no-op인지 검증한다.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from src.core.chains import RAGPipeline
+from src.pipeline.orchestrator import PipelineOrchestrator
+
+
+def _make_pipeline(use_cache: bool = True) -> RAGPipeline:
+    return RAGPipeline(MagicMock(), llm=MagicMock(), reranker=MagicMock(), use_cache=use_cache)
+
+
+class TestChainsCacheToggle:
+    def test_cache_off_by_default(self):
+        """기본(플래그 False)에서는 use_cache=True여도 캐시를 만들지 않는다."""
+        with (
+            patch("src.core.chains.SemanticCache") as mock_cache,
+            patch("src.core.chains.TracingLogger"),
+            patch("src.core.chains.settings.SEMANTIC_CACHE_ENABLED", False),
+        ):
+            pipeline = _make_pipeline()
+            assert pipeline.cache is None
+            mock_cache.assert_not_called()
+
+    def test_cache_on_when_enabled(self):
+        """플래그를 켜고 use_cache=True면 캐시가 생성된다."""
+        with (
+            patch("src.core.chains.SemanticCache") as mock_cache,
+            patch("src.core.chains.TracingLogger"),
+            patch("src.core.chains.settings.SEMANTIC_CACHE_ENABLED", True),
+        ):
+            pipeline = _make_pipeline()
+            assert pipeline.cache is mock_cache.return_value
+            mock_cache.assert_called_once()
+
+    def test_use_cache_false_overrides_enabled(self):
+        """플래그가 켜져 있어도 use_cache=False(예: 평가)면 캐시를 만들지 않는다."""
+        with (
+            patch("src.core.chains.SemanticCache") as mock_cache,
+            patch("src.core.chains.TracingLogger"),
+            patch("src.core.chains.settings.SEMANTIC_CACHE_ENABLED", True),
+        ):
+            pipeline = _make_pipeline(use_cache=False)
+            assert pipeline.cache is None
+            mock_cache.assert_not_called()
+
+
+class TestOrchestratorCacheToggle:
+    def _build(self, enabled: bool) -> PipelineOrchestrator:
+        PipelineOrchestrator._instance = None
+        with (
+            patch("src.pipeline.orchestrator.IngestionPipeline"),
+            patch("src.pipeline.orchestrator.StorageManager"),
+            patch("src.pipeline.orchestrator.SemanticCache") as mock_cache,
+            patch("src.pipeline.orchestrator.settings.SEMANTIC_CACHE_ENABLED", enabled),
+        ):
+            orch = PipelineOrchestrator()
+            return orch, mock_cache
+
+    def test_cache_off_by_default(self):
+        """기본(플래그 False)에서는 오케스트레이터가 캐시를 만들지 않는다."""
+        orch, mock_cache = self._build(enabled=False)
+        assert orch.cache is None
+        mock_cache.assert_not_called()
+
+    def test_cache_on_when_enabled(self):
+        """플래그를 켜면 오케스트레이터가 캐시를 생성한다."""
+        orch, mock_cache = self._build(enabled=True)
+        assert orch.cache is mock_cache.return_value
+        mock_cache.assert_called_once()

--- a/src/tests/unit/core/test_memory.py
+++ b/src/tests/unit/core/test_memory.py
@@ -25,6 +25,7 @@ class TestRAGPipelineMemory:
         with (
             patch("src.core.chains.SemanticCache") as mock_cache_class,
             patch("src.core.chains.TracingLogger") as mock_logger_class,
+            patch("src.core.chains.settings.SEMANTIC_CACHE_ENABLED", True),
         ):
             mock_cache_class.return_value = MagicMock()
             mock_logger_class.return_value = MagicMock()

--- a/src/tests/unit/core/test_memory.py
+++ b/src/tests/unit/core/test_memory.py
@@ -72,7 +72,7 @@ class TestRAGPipelineMemory:
     def test_semantic_cache_with_history(self, pipeline, mock_retriever, mock_llm, mock_reranker):
         """대화 이력이 존재할 때도 캐시를 정상적으로 조회 및 저장하는지 검증"""
         # pipeline 피스처 내부에 모킹된 캐시 가져오기
-        mock_cache = pipeline.cache
+        mock_cache = pipeline._get_cache()
         mock_cache.get.return_value = None
 
         history = [{"role": "user", "content": "질문"}]

--- a/src/tests/unit/pipeline/test_orchestrator_ext.py
+++ b/src/tests/unit/pipeline/test_orchestrator_ext.py
@@ -18,7 +18,7 @@ def orchestrator():
         orch = PipelineOrchestrator()
         orch.ingestion_pipeline = MagicMock()
         orch.storage_manager = MagicMock()
-        orch.cache = MagicMock()
+        orch._cache = MagicMock()
         yield orch
 
 


### PR DESCRIPTION
Resolves #157

## 변경 사항 (Checklist)

* [ ] 새로운 기능 추가 (feature)
* [ ] 버그 수정 (fix)
* [x] 리팩토링 (refactor)
* [ ] 문서 수정 (docs)
* [ ] 환경 설정 (setup)

## 주요 작업 내용

- `config.py`: `SEMANTIC_CACHE_ENABLED: bool = Field(default=False)` 추가(기본 비활성, opt-in). pydantic-settings라 env/.env/런타임으로 토글.
- `chains.py`(RAGPipeline): `_get_cache()` 추가 — 호출 시점에 `use_cache and settings.SEMANTIC_CACHE_ENABLED`를 판별해 **켜진 경우에만 최초 1회 lazy 생성 + 메모이즈**한다. `stream()`의 캐시 조회/적재가 이 게이트를 사용. 평가의 `use_cache=False`는 영구 비활성으로 우선.
- `orchestrator.py`: 동일하게 `_get_cache()` 런타임 게이트 + 색인 시 `flush` 게이트. 생성자 정적 판별을 제거해 "켠 상태로 색인 시 stale 캐시 flush 누락" 정합성 구멍을 막음.
- `app.py`: 사이드바 `기타 설정`에 "시맨틱 캐시 활성화" 토글 추가 → `settings`에 즉시 반영(재기동 없이 on/off), `is_generating` 중 비활성, help 툴팁으로 FP 위험·기본 비활성 안내.
- 캐시 클래스(`cache.py`)·임계값·get/add/flush 로직은 **무변경**(코드 보존).

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**: 자체 시맨틱 캐시가 `query_text` 유사도만으로 히트를 판정해 "2020년"↔"2021년"처럼 미세하지만 결정적인 차이를 못 가르고 과거 오답을 반환하는 False Positive 리스크가 있었다. 원안(#157)은 전면 폐기였다.
* **원인 분석**: 폐기하면 향후 재도입·실험 비용이 크다. 또한 `@st.cache_resource`로 파이프라인이 싱글톤 공유되어, 생성자 시점에 플래그를 굳히면 설정을 바꿔도 재기동해야 반영되는 한계가 있었다(리뷰 지적).
* **해결 방안 및 의사결정**: 폐기 대신 **기본 OFF 토글**(코드 보존)로 전환하고, 정적 판별을 호출 시점 `_get_cache()`의 **lazy 생성 + 메모이즈**로 옮겨 재기동 없이 실시간 on/off가 되게 했다(기본 OFF면 객체조차 미생성 → idle 0). 오케스트레이터 생성자의 정적 판별도 제거해 flush 정합성 구멍을 막고, 사이드바 토글로 `settings`를 즉시 갱신했다. 전역 `settings` 변이(세션 간 공유)는 내부 관리자 운영 도구 전제로 수용하고 주석에 명시했다.
* **결과**: 재기동 없이 캐시 on/off, 기본 OFF로 FP 위험 차단, 평가(`use_cache=False`)는 영구 비활성. 켤 때의 동작은 기존과 동일.

## 테스트 결과 / 결과 증빙 (Screenshots / Logs)

- 런타임 토글 게이트 단위 테스트: OFF(기본)면 캐시 미생성·get/add/flush no-op / ON이면 최초 1회 lazy 생성·메모이즈 / 런타임 플래그만 바꿔 재생성 없이 on→off→on / `use_cache=False`는 플래그 ON이어도 OFF.
- `test_memory`(캐시-활성 동작 검증)는 플래그 ON 명시.
- 전체 unit **261개 통과**, ruff check + format 통과.
- **UI 증빙**: 사이드바 `기타 설정` → "시맨틱 캐시 활성화" 토글 + `?` help 툴팁 렌더링 화면.
<img width="216" height="124" alt="스크린샷 2026-06-06 204253" src="https://github.com/user-attachments/assets/a7587f26-48f2-4d3c-b3d3-c7a89498cbaa" />


## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요? — base develop
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
* [x] 관련 이슈 번호를 연결했나요? (Resolves #157)
* [x] 주간 발표 자료로 활용 가능한 직관적인 결과물(스크린샷/로그)을 첨부했나요? — UI 토글 스크린샷(위 증빙 섹션)
* [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디

런타임 동적 제어 피드백을 반영해 생성자 정적 판별 → 호출 시점 lazy 생성으로 바꿨고, 재기동 없이 토글되는 단위 테스트도 추가했습니다. 요청하신 사이드바 토글 + 툴팁 UI 스크린샷은 위 증빙 섹션에 첨부했습니다.

Generated with Claude Code (https://claude.com/claude-code)

