### PR TITLE
feat(eval): 기본 LLM을 gemma4:e2b로 변경하고 평가 요약에 자원 평균 추가 (#178)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 # 1. LLM 및 임베딩 모델 설정
 # MODEL_TYPE: gemini, claude, ollama (기본값: ollama)
 MODEL_TYPE=ollama
-MODEL_NAME=gemma2:2b
+MODEL_NAME=gemma4:e2b
 EMBEDDING_MODEL_NAME=BAAI/bge-m3
 
 # 로컬 실행 시: http://localhost:11434

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -29,7 +29,7 @@ class Settings(BaseSettings):
 
     # 1. LLM 및 모델 설정
     MODEL_TYPE: Literal["gemini", "claude", "ollama"] = Field(default="ollama")
-    MODEL_NAME: str = Field(default="llama3.2:1b")
+    MODEL_NAME: str = Field(default="gemma4:e2b")
     EMBEDDING_MODEL_NAME: str = Field(default="BAAI/bge-m3")
     TEMPERATURE: float = Field(default=0.1)
 

--- a/src/eval/evaluator.py
+++ b/src/eval/evaluator.py
@@ -173,6 +173,19 @@ def _get_resource_snapshot() -> dict[str, float]:
     return snapshot
 
 
+def _average_resources(df: pd.DataFrame) -> dict[str, float]:
+    """샘플별 자원 스냅샷(cpu/ram/vram)에서 평균을 집계한다.
+
+    GPU 미탑재 등으로 수집되지 않은 항목(예: vram_mb 열 부재)은 건너뛴다.
+    """
+    columns = {"cpu_percent": "avg_cpu_percent", "ram_mb": "avg_ram_mb", "vram_mb": "avg_vram_mb"}
+    averages: dict[str, float] = {}
+    for col, out_key in columns.items():
+        if col in df.columns and not df[col].isna().all():
+            averages[out_key] = round(float(df[col].mean()), 1)
+    return averages
+
+
 async def run_rag_inference(test_data: list[dict[str, Any]]) -> InferenceResult:
     """RAG 추론 수행 및 SingleTurnSample 리스트 생성 (시스템 표준 체인 사용)"""
     from src.core.chains import get_rag_chain
@@ -351,6 +364,7 @@ async def _score_and_save(result: InferenceResult, missing_docs: list[str] | Non
         "results": {
             **avg_scores,
             "avg_latency_sec": avg_latency,
+            **_average_resources(df),
             "total_samples": len(df),
         },
         "system": _get_system_info(),

--- a/src/tests/unit/core/test_evaluator.py
+++ b/src/tests/unit/core/test_evaluator.py
@@ -1,9 +1,15 @@
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 from ragas import SingleTurnSample
 
-from src.eval.evaluator import InferenceResult, _get_inference_settings, run_rag_inference
+from src.eval.evaluator import (
+    InferenceResult,
+    _average_resources,
+    _get_inference_settings,
+    run_rag_inference,
+)
 
 
 @pytest.fixture
@@ -109,3 +115,32 @@ def test_inference_settings_non_ollama_only_common(monkeypatch):
     assert "temperature" in info
     assert "num_predict" not in info
     assert all(not k.startswith(("num_", "repeat_", "keep_", "think")) for k in info)
+
+
+def test_average_resources_includes_vram_when_present():
+    """vram_mb 열이 있으면 cpu/ram/vram 평균을 모두 집계한다."""
+    df = pd.DataFrame(
+        [
+            {"cpu_percent": 10.0, "ram_mb": 1000.0, "vram_mb": 500.0},
+            {"cpu_percent": 20.0, "ram_mb": 2000.0, "vram_mb": 1500.0},
+        ]
+    )
+
+    avg = _average_resources(df)
+
+    assert avg == {"avg_cpu_percent": 15.0, "avg_ram_mb": 1500.0, "avg_vram_mb": 1000.0}
+
+
+def test_average_resources_omits_vram_when_absent():
+    """GPU 미탑재로 vram_mb 열이 없으면 cpu/ram만 집계하고 vram은 생략한다."""
+    df = pd.DataFrame(
+        [
+            {"cpu_percent": 10.0, "ram_mb": 1000.0},
+            {"cpu_percent": 30.0, "ram_mb": 3000.0},
+        ]
+    )
+
+    avg = _average_resources(df)
+
+    assert avg == {"avg_cpu_percent": 20.0, "avg_ram_mb": 2000.0}
+    assert "avg_vram_mb" not in avg


### PR DESCRIPTION
Resolves #178

## 변경 사항 (Checklist)

* [x] 새로운 기능 추가 (feature)
* [ ] 버그 수정 (fix)
* [ ] 리팩토링 (refactor)
* [ ] 문서 수정 (docs)
* [ ] 환경 설정 (setup)

## 주요 작업 내용

- `config.py`: `MODEL_NAME` 기본값 `llama3.2:1b` → `gemma4:e2b`.
- `.env.example`: 템플릿의 `MODEL_NAME`을 `gemma4:e2b`로 동기화.
- `evaluator.py`: `_average_resources(df)` 헬퍼 추가 — `cpu_percent`/`ram_mb`/`vram_mb` 평균을 계산해 요약 `results`에 기록(`avg_cpu_percent`/`avg_ram_mb`/`avg_vram_mb`). GPU 미탑재로 `vram_mb` 열이 없으면 컬럼 가드로 생략.

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**: 기본 모델(`llama3.2:1b`)이 자원 대비 비효율이었고, 모델별 자원 footprint를 평가 요약에서 바로 비교할 수 없었다. 자원 스냅샷(cpu/ram/vram)은 샘플 단위로 수집돼 상세 CSV에는 들어갔지만, 요약 JSON `results`에는 점수·지연만 집계돼 비교 때마다 CSV를 수기 집계해야 했다.
* **원인 분석**: (1) 기본 모델이 경량 옵션으로 정해져 있지 않았다. (2) `_get_resource_snapshot`의 값이 `row.update(resource)`로 상세 CSV에는 흘러갔지만 `summary_data["results"]` 집계에는 누락돼 있었다.
* **해결 방안 및 의사결정**: 같은 골든셋·환경의 실측 평가로 `gemma4:e2b` vs `e4b`를 비교해(아래 증빙), 지연이 ~1.6배 낮고 품질 손실이 작은 **e2b를 일반 기본값**으로 채택했다(e4b는 고품질 fallback 유지). 요약에는 수치를 하드코딩하지 않고 `_average_resources`로 측정값 평균을 집계하며, GPU 미탑재 시 `vram_mb` 컬럼이 없으면 가드로 생략한다.
* **결과**: 경량 기본 모델 + 요약 한 파일에서 점수·지연·자원(cpu/ram/vram)을 함께 비교 가능.

## 테스트 결과 / 결과 증빙 (Screenshots / Logs)

**모델 선택 근거 — gemma4:e2b vs e4b 실측** (동일 RTX 5080 / Ryzen 9800X3D · 동일 골든셋 50문항 · 동일 리트리버·리랭커·judge):

| 지표 | gemma4:e2b | gemma4:e4b | 비고 |
| --- | --- | --- | --- |
| avg_latency_sec | **4.45** | 7.25 | e2b ≈1.6배 빠름 |
| faithfulness | 0.892 | **0.924** | e4b +0.031 |
| answer_relevancy | 0.735 | **0.750** | e4b +0.014 |
| context_precision | 0.911 | 0.912 | 사실상 동일(리트리버 지표) |
| context_recall | 0.974 | **0.988** | e4b +0.014 |

출처: `eval_summary_20260605_152056.json`(e2b) · `eval_summary_20260604_002213.json`(e4b). `context_*`는 리트리버에 좌우되어 모델 간 거의 동일. 위 요약들엔 cpu/ram/vram 평균이 아직 없는데, 그게 이 PR이 채우는 항목이라 다음 평가부터 자원까지 같은 파일에서 비교된다.

**단위 테스트 / 정적 검사**

- `_average_resources` 단위 테스트 2개 추가: VRAM 열이 있을 때 cpu/ram/vram 평균 집계, 없을 때(GPU 무) cpu/ram만 집계하고 vram 생략.
- 전체 unit **259개 통과**, ruff check + format 통과.

## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요? — base develop
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
* [x] 관련 이슈 번호를 연결했나요? (Resolves #178)
* [x] 주간 발표 자료로 활용 가능한 직관적인 결과물(스크린샷/로그)을 첨부했나요? — e2b vs e4b 실측 비교표
* [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디

배포 환경의 모델 지정이 코드 기본값과 분리된 파편화(docker/terraform)는 이번 범위 밖으로 두고, 후속 이슈 #181(SSoT 일원화)로 분리했습니다. e2b/e4b 비교는 추측이 아니라 동일 조건 평가 요약 실측치입니다.

Generated with Claude Code (https://claude.com/claude-code)
