### PR TITLE
feat(infra): 모델명을 .env.example 단일 출처(SSoT)로 일원화 (#181)

### DIFF
--- a/docker/ollama_init.sh
+++ b/docker/ollama_init.sh
@@ -27,8 +27,8 @@ until ollama list > /dev/null 2>&1; do
     sleep 2
 done
 
-# .env 또는 환경 변수에서 모델명 가져오기 (기본값: gemma2:2b)
-MODEL_NAME=${MODEL_NAME:-"gemma2:2b"}
+# .env 또는 환경 변수에서 모델명 가져오기 (폴백은 앱 설정과 동일한 gemma4:e2b)
+MODEL_NAME=${MODEL_NAME:-"gemma4:e2b"}
 
 # 사용하지 않는 기존 모델 자동 삭제 (디스크 용량 최적화)
 echo "Cleaning up outdated models..."

--- a/terraform/modules/ec2/main.tf
+++ b/terraform/modules/ec2/main.tf
@@ -39,6 +39,13 @@ data "aws_ami" "ubuntu_gpu" {
   }
 }
 
+# 모델명 Single Source of Truth: 레포 .env.example의 MODEL_NAME을 읽어 배포 user_data에 주입한다.
+# 하드코딩을 없애 .env.example 한 곳만 바꾸면 EC2 배포까지 동기화된다. 파일/항목이 없으면 앱 기본값으로 폴백. (#181)
+locals {
+  env_example_path = "${path.module}/../../../.env.example"
+  model_name       = try(trimspace(regex("(?m)^MODEL_NAME=(.*)$", file(local.env_example_path))[0]), "gemma4:e2b")
+}
+
 resource "aws_instance" "app" {
   ami                  = data.aws_ami.ubuntu_gpu.id
   instance_type        = var.instance_type
@@ -108,7 +115,7 @@ git checkout feature/issue-89-local-infra || echo "Branch not found, using defau
 echo "Creating .env file..."
 cat <<EOT > .env
 MODEL_TYPE=ollama
-MODEL_NAME=llama3.2:1b
+MODEL_NAME=${local.model_name}
 EMBEDDING_MODEL_NAME=BAAI/bge-m3
 OLLAMA_BASE_URL=http://ollama:11434
 CHROMA_SERVER_HOST=chromadb


### PR DESCRIPTION
Resolves #181

## 변경 사항 (Checklist)

* [ ] 새로운 기능 추가 (feature)
* [ ] 버그 수정 (fix)
* [ ] 리팩토링 (refactor)
* [ ] 문서 수정 (docs)
* [x] 환경 설정 (setup)

## 주요 작업 내용

- `docker/ollama_init.sh`: 하드코딩 폴백 `gemma2:2b` → `gemma4:e2b`(앱 기본값과 정렬). `docker-compose.yml`의 `app`·`ollama` 서비스는 이미 `env_file: - .env`로 `.env`를 전달하므로 매핑 추가는 하지 않음(확인됨).
- `terraform/modules/ec2/main.tf`: `locals`에서 레포 `.env.example`의 `MODEL_NAME`을 `regex` + `file`로 추출(파일/항목이 없으면 `try`로 `gemma4:e2b` 폴백)하고, user_data heredoc의 하드코딩 `MODEL_NAME=llama3.2:1b`를 `${local.model_name}`으로 치환.
- 결과적으로 `.env.example`의 `MODEL_NAME` 한 줄만 바꾸면 개발/도커/EC2 배포가 같은 모델로 동기화된다. (#180 머지 시 `gemma4:e2b`가 이 경로로 자동 반영.)

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**: 모델을 바꾸려면 `config.py`·`.env.example`·`docker/ollama_init.sh`·`terraform .../main.tf`를 따로 고쳐야 했고, 실제로 네 곳이 제각각(`llama3.2:1b`/`gemma2:2b`)이라 배포 인스턴스가 앱 기본값과 다른 모델로 기동될 수 있었다.
* **원인 분석**: 영역별 파편화 정도가 달랐다. 앱(pydantic-settings)·Docker(compose `env_file`)는 이미 `.env`를 읽고 있었고, 실질 위반은 (1) Terraform `user_data`가 heredoc으로 자체 `.env`를 만들며 `MODEL_NAME`을 하드코딩한 점, (2) `ollama_init.sh`의 stale 폴백 리터럴(`gemma2:2b`)이었다.
* **해결 방안 및 의사결정**: 리뷰 제안 중 "compose 매핑 추가"는 현 코드 확인 결과 이미 `env_file`로 충족되어 불필요한 변경을 피했다. Terraform은 heredoc 전면 재작성 대신 `locals` + `file()` + `regex()`로 `.env.example`에서 **모델명만** 추출해 user_data에 보간하는 최소 변경을 택했고(다른 배포 전용 값은 오버라이드로 유지), `try()`로 파일/항목 누락 시 앱 기본값 폴백을 뒀다.
* **결과**: 모델명 SSoT가 `.env.example` 한 곳으로 모인다. dev/docker/배포가 단일 소스로 동기화.

## 테스트 결과 / 결과 증빙 (Screenshots / Logs)

* `bash -n docker/ollama_init.sh` → 문법 통과.
* 변경 파일 grep 결과 옛 모델명(`llama3.2:1b`/`gemma2:2b`) 잔존 없음.
* 변경 후 user_data 생성 라인: `MODEL_NAME=${local.model_name}` ← `.env.example`의 `MODEL_NAME`을 plan 시점에 보간.
* 한계: 로컬에 terraform 바이너리가 없어 `terraform fmt`/`validate`를 실행하지 못했다. HCL은 수동 검토(user_data는 `<<-EOF` 보간형 heredoc, 기존 bash는 `$()`/`$VAR`만 써서 `${local.model_name}` 추가가 안전). CI/리뷰어 환경에서 fmt/validate 확인 부탁.

## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요? — develop에서 분기
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
* [x] 관련 이슈 번호를 연결했나요? (Resolves #181)
* [ ] 주간 발표 자료로 활용 가능한 직관적인 결과물(스크린샷/로그)을 첨부했나요? — 인프라 변경이라 스크린샷 없음, 위 검증 로그로 대체
* [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디

리뷰 제안 중 docker-compose 매핑은 이미 `env_file: - .env`로 충족되어 있어 생략했고(확인), 실질 작업은 Terraform SSoT로 좁혔습니다. 로컬에 terraform이 없어 `fmt`/`validate`만 못 돌렸으니 그 부분 확인 부탁드립니다.

Generated with Claude Code (https://claude.com/claude-code)
