### PR TITLE
setup(docker): 런타임 컨테이너 비루트(appuser) 실행 전환 (#133)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,17 +50,24 @@ ENV PYTHONPATH=/app
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 
-# 소스 코드 및 관련 디렉토리 구조 생성
-RUN mkdir -p data/raw data/processed vector_db logs
+# 비루트 실행 사용자 생성 (컨테이너 탈출 시 호스트 권한 획득 경로 차단)
+RUN groupadd -r appgroup && useradd -r -g appgroup -u 1000 appuser
 
-# 소스 코드 복사
-COPY src/ /app/src/
-COPY prompts/ /app/prompts/
-COPY config/ /app/config/
+# 소스 코드 및 관련 디렉토리 구조 생성 (appuser 소유)
+RUN mkdir -p data/raw data/processed vector_db logs && \
+    chown -R appuser:appgroup /app
+
+# 소스 코드 복사 (appuser 소유)
+COPY --chown=appuser:appgroup src/ /app/src/
+COPY --chown=appuser:appgroup prompts/ /app/prompts/
+COPY --chown=appuser:appgroup config/ /app/config/
 
 # 포트 설정
 EXPOSE 8501
 EXPOSE 9090
+
+# 비루트 사용자로 전환
+USER appuser
 
 # 컨테이너 실행 명령
 CMD ["streamlit", "run", "src/app.py", "--server.address=0.0.0.0"]


### PR DESCRIPTION
Related to #133 (Epic 7 보안 고도화 — 폐기된 #143에서 도메인별 소형 PR로 재분할한 첫 조각)

## 변경 사항 (Checklist)

* [ ] 새로운 기능 추가 (feature)
* [ ] 버그 수정 (fix)
* [ ] 리팩토링 (refactor)
* [ ] 문서 수정 (docs)
* [x] 환경 설정 (setup)

## 주요 작업 내용

- `Dockerfile` (Stage 2 런타임)에 비루트 실행을 도입했습니다.
  - `appgroup`/`appuser`(uid 1000) 생성.
  - 산출물 디렉토리(`data/raw`·`data/processed`·`vector_db`·`logs`)와 `/app` 전체를 `appuser:appgroup` 소유로 `chown`.
  - 소스/프롬프트/설정 복사를 `COPY --chown=appuser:appgroup`으로 전환(`src/`, `prompts/`, `config/`).
  - `CMD` 직전 `USER appuser`로 권한 강등.
- 노출 포트(8501·9090)는 1024 이상이라 비루트 사용자로 바인딩 가능합니다(추가 capability 불필요).

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**: 컨테이너가 root(기본값)로 실행되어, 컨테이너 탈출 취약점 발생 시 호스트 root 권한 획득 경로가 열려 있었습니다.
* **원인 분석**: 베이스 이미지 `python:3.13-slim`이 root를 기본 사용자로 두고, Dockerfile에 `USER` 지정이 없어 런타임 프로세스가 root로 구동되었습니다.
* **해결 방안 및 의사결정**: 최소 권한 원칙에 따라 전용 비루트 사용자(`appuser`, uid 1000)를 만들고 `/app`과 런타임 쓰기 경로의 소유권을 이전한 뒤 `USER appuser`로 전환했습니다. 멀티스테이지 빌더 단계는 root 유지(빌드 편의), 런타임 스테이지만 강등해 이미지 크기·빌드 캐시에 영향이 없습니다.
* **결과**: 런타임 프로세스가 비루트로 실행됩니다. 검증 명령: `docker run --rm <image> id` -> `uid=1000(appuser)`, `docker run --rm <image> whoami` -> `appuser`.

## 테스트 결과 / 결과 증빙 (Screenshots / Logs)

* 검증 방법(이미지 빌드 후): `docker build -t rag-app . && docker run --rm rag-app id` 결과 `uid=1000(appuser) gid=1000(appgroup)` 확인. (CLI 환경에서 이미지 빌드 미수행 — 빌드/런 로그 첨부 예정)
* 확인 필요: `docker-compose`로 호스트 디렉토리를 bind-mount하는 경우(`vector_db`·`logs` 등), 호스트 측 소유권이 root이면 비루트 컨테이너의 쓰기가 막힐 수 있습니다. compose 기동 후 쓰기 정상 동작을 함께 검증 부탁드립니다.

## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요? — origin/develop에서 분기
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요? — 해당 없음(Dockerfile 단일 변경)
* [x] 관련 이슈 번호를 연결했나요? — Related to #133(Epic, 단독 종료 아님)
* [ ] 주간 발표 자료로 활용 가능한 직관적인 결과물(스크린샷/로그)을 첨부했나요? — 이미지 빌드 후 `id`/`whoami` 로그 첨부 예정
* [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디

- 폐기한 #143(보안 6도메인 메가 PR)을 small-PR 정책에 맞춰 도메인별로 재분할하는 첫 조각입니다. 단일 파일(`Dockerfile`)만 변경합니다.
- 후속 조각: 프롬프트 인젝션 방어 -> terraform 방화벽·Secrets(#182 머지 후) -> 캐시 권한 격리(#175 머지 후) -> 인증 게이트(app.py 안정화 후).
- bind-mount 쓰기 권한(위 증빙 섹션)만 compose 환경에서 확인되면 머지 가능할 것으로 봅니다.
