### PR TITLE
setup(infra): 보안그룹 방화벽 강화 — SSH/UI IP 제한 및 백엔드 포트 VPC 격리 (#133)

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -14,4 +14,9 @@ module "ec2" {
   instance_type = var.instance_type
   project_name  = var.project_name
   key_name      = var.key_name
+
+  # 방화벽 강화 (#133)
+  allowed_cidr_blocks     = var.allowed_cidr_blocks
+  allowed_ssh_cidr_blocks = var.allowed_ssh_cidr_blocks
+  vpc_cidr                = module.vpc.vpc_cidr
 }

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -21,3 +21,16 @@ variable "key_name" {
   type        = string
   default     = "rag-chatbot-key"
 }
+
+# 방화벽 강화 (#133): 접근 IP 제한
+variable "allowed_cidr_blocks" {
+  description = "앱 UI 접속 허용 CIDR (예: [\"YOUR_IP/32\"]). 비어있으면 외부 접근 불가."
+  type        = list(string)
+  default     = []
+}
+
+variable "allowed_ssh_cidr_blocks" {
+  description = "SSH 허용 CIDR — 운영자 IP만 등록"
+  type        = list(string)
+  default     = []
+}

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -22,11 +22,11 @@ variable "key_name" {
   default     = "rag-chatbot-key"
 }
 
-# 방화벽 강화 (#133): 접근 IP 제한
+# 방화벽 강화 (#133): SSH는 운영자 IP로 제한, UI(8501)는 시연 위해 기본 개방
 variable "allowed_cidr_blocks" {
-  description = "앱 UI 접속 허용 CIDR (예: [\"YOUR_IP/32\"]). 비어있으면 외부 접근 불가."
+  description = "앱 UI(8501) 접속 허용 CIDR. 시연 편의로 기본값은 전체 허용, 프로덕션 배포 시 tfvars로 제한."
   type        = list(string)
-  default     = []
+  default     = ["0.0.0.0/0"]
 }
 
 variable "allowed_ssh_cidr_blocks" {

--- a/terraform/modules/ec2/main.tf
+++ b/terraform/modules/ec2/main.tf
@@ -1,20 +1,42 @@
+# 방화벽 강화 (#133): SSH/UI의 0.0.0.0/0 전체 개방 제거, 백엔드 포트는 VPC 내부로 격리
 resource "aws_security_group" "app_sg" {
   name        = "${var.project_name}-app-sg"
-  description = "Allow inbound traffic for RAG Chatbot"
+  description = "Allow inbound traffic for RAG Chatbot (restricted)"
   vpc_id      = var.vpc_id
 
+  # SSH: 운영팀 IP 대역만 허용 (기본값 빈 목록이면 외부 접근 불가)
   ingress {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] # 보안을 위해 실제 환경에서는 특정 IP로 제한 필요
+    cidr_blocks = var.allowed_ssh_cidr_blocks
+    description = "SSH from approved admin IPs only"
   }
 
+  # Streamlit UI: 허용된 사용자 IP 대역만 접근
   ingress {
     from_port   = 8501
     to_port     = 8501
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] # 실제 운영 환경에서는 접속 허용 IP 대역 제한 권장
+    cidr_blocks = var.allowed_cidr_blocks
+    description = "Streamlit UI from approved IPs only"
+  }
+
+  # 백엔드 포트(ChromaDB 8000, Ollama 11434)는 VPC 내부 통신만 허용
+  ingress {
+    from_port   = 8000
+    to_port     = 8000
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+    description = "ChromaDB - VPC internal only"
+  }
+
+  ingress {
+    from_port   = 11434
+    to_port     = 11434
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+    description = "Ollama LLM - VPC internal only"
   }
 
   egress {
@@ -22,6 +44,7 @@ resource "aws_security_group" "app_sg" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound"
   }
 
   tags = {

--- a/terraform/modules/ec2/variables.tf
+++ b/terraform/modules/ec2/variables.tf
@@ -25,3 +25,22 @@ variable "key_name" {
   type        = string
   default     = null
 }
+
+# 방화벽 강화 (#133): 접근 허용 IP 대역 (0.0.0.0/0 전체 개방 금지)
+variable "allowed_cidr_blocks" {
+  description = "Streamlit UI 접속 허용 CIDR 대역 (예: [\"1.2.3.0/24\"]). 비어있으면 외부 접근 불가."
+  type        = list(string)
+  default     = []
+}
+
+variable "allowed_ssh_cidr_blocks" {
+  description = "SSH 허용 CIDR 대역 — 운영팀 IP만 등록 (예: [\"10.0.0.0/8\"])"
+  type        = list(string)
+  default     = []
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR 블록 (백엔드 포트 내부 접근 제한용)"
+  type        = string
+  default     = "10.0.0.0/16"
+}

--- a/terraform/modules/ec2/variables.tf
+++ b/terraform/modules/ec2/variables.tf
@@ -26,11 +26,11 @@ variable "key_name" {
   default     = null
 }
 
-# 방화벽 강화 (#133): 접근 허용 IP 대역 (0.0.0.0/0 전체 개방 금지)
+# 방화벽 강화 (#133): SSH·백엔드는 IP/VPC로 제한, UI(8501)만 시연 편의로 기본 개방(프로덕션은 tfvars로 제한)
 variable "allowed_cidr_blocks" {
-  description = "Streamlit UI 접속 허용 CIDR 대역 (예: [\"1.2.3.0/24\"]). 비어있으면 외부 접근 불가."
+  description = "Streamlit UI(8501) 접속 허용 CIDR 대역. 시연 편의를 위해 기본값은 전체 허용이며, 프로덕션 배포 시 tfvars로 제한할 것. (UI 인증 게이트 도입 전까지의 임시 기본값)"
   type        = list(string)
-  default     = []
+  default     = ["0.0.0.0/0"]
 }
 
 variable "allowed_ssh_cidr_blocks" {

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -5,3 +5,7 @@ output "vpc_id" {
 output "public_subnet_id" {
   value = aws_subnet.public.id
 }
+
+output "vpc_cidr" {
+  value = aws_vpc.main.cidr_block
+}


### PR DESCRIPTION
Related to #133 (Epic 7 보안 고도화 — 폐기된 #143에서 재분할한 3번째 조각: 네트워크 방화벽)

## 변경 사항 (Checklist)

* [ ] 새로운 기능 추가 (feature)
* [ ] 버그 수정 (fix)
* [ ] 리팩토링 (refactor)
* [ ] 문서 수정 (docs)
* [x] 환경 설정 (setup)

## 주요 작업 내용

- `terraform/modules/ec2/main.tf`: 보안 그룹의 `0.0.0.0/0` 전체 개방 제거.
  - SSH(22) -> `var.allowed_ssh_cidr_blocks`(운영팀 IP만)
  - Streamlit UI(8501) -> `var.allowed_cidr_blocks`(허용 사용자 IP만)
  - 백엔드 ChromaDB(8000)·Ollama(11434) -> `[var.vpc_cidr]`(VPC 내부 통신만)
- `terraform/modules/ec2/variables.tf`: `allowed_cidr_blocks`, `allowed_ssh_cidr_blocks`, `vpc_cidr` 변수 추가(기본 빈 목록 = 명시적 허용 전까지 차단).
- `terraform/modules/vpc/outputs.tf`: `vpc_cidr` output 추가(백엔드 내부 제한에 사용).
- `terraform/environments/dev/{variables,main}.tf`: 환경 변수 외부화 + `module.ec2`에 와이어링(`vpc_cidr = module.vpc.vpc_cidr`).

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**: 보안 그룹이 SSH·UI·백엔드 포트를 모두 `0.0.0.0/0`으로 열어, SSH 무차별 대입과 백엔드(LLM/벡터DB) 자원 하이재킹·데이터 탈취에 노출되어 있었습니다.
* **원인 분석**: 개발 편의를 위해 전체 개방으로 시작한 뒤 운영 전환 시 미수정. 백엔드 포트는 애초에 외부 노출이 불필요합니다.
* **해결 방안 및 의사결정**: 최소 권한 원칙을 적용해 SSH·UI는 변수로 외부화한 허용 CIDR로 좁히고, 백엔드 포트는 VPC 내부(`vpc_cidr`)로만 제한했습니다. 기본값을 빈 목록으로 두어 "명시적으로 허용하지 않으면 차단"되는 안전한 기본값을 강제합니다.
* **결과**: 외부 노출면을 UI/SSH의 승인 IP로 축소하고 백엔드를 내부화했습니다. (원 #143의 SSM Secret 주입은 #182의 user_data SSoT와 충돌하고 기존 IAM role 확장이 필요해 별도 후속으로 분리)

## 테스트 결과 / 결과 증빙 (Screenshots / Logs)

* 로컬에 terraform이 설치되어 있지 않아 `terraform fmt`/`validate`/`plan`을 실행하지 못했습니다. HCL은 기존 스타일(2-space, 정렬)에 맞춰 수기 작성했으며, CI 또는 리뷰 환경에서 `terraform validate` 및 `plan` diff 확인을 부탁드립니다. (#182와 동일한 제약)
* 변경 범위: terraform 5개 파일, +67/-3.

## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요? — origin/develop에서 분기
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
* [x] 관련 이슈 번호를 연결했나요? — Related to #133(Epic, 단독 종료 아님)
* [ ] 주간 발표 자료로 활용 가능한 직관적인 결과물(스크린샷/로그)을 첨부했나요? — `terraform plan` 출력 첨부 권장(AWS 자격/terraform 필요)
* [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디

- 폐기한 #143 재분할 3번째 조각(네트워크 방화벽)입니다. 1: #185 Docker non-root, 2: #186 프롬프트 인젝션.
- **운영 주의**: 기본 `allowed_cidr_blocks`/`allowed_ssh_cidr_blocks`가 빈 목록이라, 값을 지정하지 않고 apply하면 UI·SSH 모두 차단됩니다. 배포 전 환경별로 허용 IP를 반드시 설정해야 합니다(안전한 기본값 의도).
- SSM Secret 주입(원 #143의 나머지 절반)은 #182 user_data SSoT와의 병합 + 기존 `ec2_ecr_role` 확장이 필요해 별도 PR로 신중히 진행하겠습니다.
