### PR TITLE
feat(core): 환각 방지 강화 및 리랭커 타임아웃 활성화 토글 기능 추가

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -287,13 +287,18 @@ with st.sidebar:
     # 4. 기타 설정
     st.toggle("상세 추론 과정 보기", key="show_expert_mode", disabled=st.session_state.is_generating)
 
-    # 시맨틱 캐시 런타임 토글: 전역 settings에 즉시 반영해 재기동 없이 on/off (#157).
-    # settings는 프로세스 전역 단일 객체 — 내부 관리자 운영 도구 전제이므로 세션 간 공유를 수용한다.
     settings.SEMANTIC_CACHE_ENABLED = st.toggle(
         "시맨틱 캐시 활성화",
         value=settings.SEMANTIC_CACHE_ENABLED,
         disabled=st.session_state.is_generating,
         help="질의 유사도 기반 캐시. 미세한 질의 차이를 못 가르는 오탐 위험이 있어 기본 비활성입니다.",
+    )
+
+    settings.RERANKER_TIMEOUT_ENABLED = st.toggle(
+        "리랭커 타임아웃 활성화",
+        value=settings.RERANKER_TIMEOUT_ENABLED,
+        disabled=st.session_state.is_generating,
+        help="리랭커 추론 시간제한(기본 5초) 적용 여부를 설정합니다. 비활성화 시 타임아웃 없이 모델 연산 완료를 무기한 대기합니다.",
     )
 
     # API 토큰 사용량 및 실시간 과금 추적

--- a/src/app.py
+++ b/src/app.py
@@ -298,7 +298,10 @@ with st.sidebar:
         "리랭커 타임아웃 활성화",
         value=settings.RERANKER_TIMEOUT_ENABLED,
         disabled=st.session_state.is_generating,
-        help="리랭커 추론 시간제한(기본 5초) 적용 여부를 설정합니다. 비활성화 시 타임아웃 없이 모델 연산 완료를 무기한 대기합니다.",
+        help=(
+            "리랭커 추론 시간제한(기본 5초) 적용 여부를 설정합니다. "
+            "비활성화 시 타임아웃 없이 모델 연산 완료를 무기한 대기합니다."
+        ),
     )
 
     # API 토큰 사용량 및 실시간 과금 추적

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -118,7 +118,8 @@ class Settings(BaseSettings):
         ]
     )
     RERANKER_SIMILARITY_THRESHOLD: float = Field(default=0.60)
-    RETRIEVER_FALLBACK_THRESHOLD: float = Field(default=0.40)
+    RETRIEVER_FALLBACK_THRESHOLD: float = Field(default=0.53)
+    RERANKER_TIMEOUT_ENABLED: bool = Field(default=True)
 
     # 5. 평가(Evaluation) 관련 설정
     EVAL_MAX_SAMPLES: int = 50

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -117,7 +117,6 @@ class Settings(BaseSettings):
             "목",
         ]
     )
-    RERANKER_SIMILARITY_THRESHOLD: float = Field(default=0.60)
     RETRIEVER_FALLBACK_THRESHOLD: float = Field(default=0.53)
     RERANKER_TIMEOUT_ENABLED: bool = Field(default=True)
 

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -118,7 +118,7 @@ class Settings(BaseSettings):
         ]
     )
     RERANKER_SIMILARITY_THRESHOLD: float = Field(default=0.60)
-    RETRIEVER_FALLBACK_THRESHOLD: float = Field(default=0.1)
+    RETRIEVER_FALLBACK_THRESHOLD: float = Field(default=0.40)
 
     # 5. 평가(Evaluation) 관련 설정
     EVAL_MAX_SAMPLES: int = 50

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -59,7 +59,7 @@ class Settings(BaseSettings):
     RETRIEVER_EXECUTOR_MAX_WORKERS: int = Field(default=8)
     RERANKER_MAX_DOCS: int = Field(default=5)
     RERANKER_BATCH_SIZE: int = Field(default=5)
-    RERANKER_THRESHOLD: float = Field(default=0.5)
+    RERANKER_THRESHOLD: float = Field(default=0.60)
     RERANKER_TIMEOUT_SEC: int = Field(default=5)
     RERANKER_GPU_RECOVERY_INTERVAL_SEC: int = Field(default=300)
     MAX_INGESTION_WORKERS: int = Field(default=4)
@@ -117,6 +117,8 @@ class Settings(BaseSettings):
             "목",
         ]
     )
+    RERANKER_SIMILARITY_THRESHOLD: float = Field(default=0.60)
+    RETRIEVER_FALLBACK_THRESHOLD: float = Field(default=0.1)
 
     # 5. 평가(Evaluation) 관련 설정
     EVAL_MAX_SAMPLES: int = 50

--- a/src/core/chains.py
+++ b/src/core/chains.py
@@ -46,6 +46,7 @@ def invalidate_source_json_cache() -> None:
     _load_source_json.cache_clear()
 
 
+
 class RAGPipeline:
     """RAG 파이프라인의 핵심 로직을 관리하는 클래스"""
 
@@ -138,34 +139,69 @@ class RAGPipeline:
 
     def _do_reranking(
         self, query: str, docs: list[Document], final_k: int, session: Any
-    ) -> tuple[list[Document], list[float]]:
+    ) -> tuple[list[Document], list[float], bool]:
+        """(final_docs, scores, reranker_skipped) 튜플 반환.
+
+        reranker_skipped=True 이면 리랭커 타임아웃/오류로 검색 결과를 그대로 통과시킨 것이며,
+        이 경우 downstream에서 rerank_score를 메타데이터에 설정하지 않아야 한다.
+        """
         with session.trace_step("reranking") as step:
             if docs:
                 pre_rerank_ids = [d.metadata.get(MetadataFields.CHUNK_ID) or "unknown" for d in docs]
                 pre_rerank_scores = [d.metadata.get("score", 0.0) for d in docs]
 
                 rerank_result = self.reranker.rerank_with_timeout(query, docs, top_k=final_k)
-                final_docs = rerank_result.documents
-                scores = rerank_result.scores
+                raw_docs = rerank_result.documents
+                raw_scores = rerank_result.scores
+                skipped = rerank_result.reranker_skipped
+
+                final_docs = []
+                scores = []
+                if skipped:
+                    # 리랭커 타임아웃/오류: 초벌 검색 점수 기준 비상 임계값 필터링 수행 (대안 A)
+                    logger.warning("리랭커가 건너뛰어졌습니다. 초벌 검색 점수 기준으로 비상 필터링을 적용합니다.")
+                    for d in raw_docs:
+                        s = d.metadata.get("score", 0.0)
+                        if s >= settings.RETRIEVER_FALLBACK_THRESHOLD:
+                            final_docs.append(d)
+                            scores.append(s)
+                else:
+                    # 리랭커 정상 실행: 리랭커 점수 기반 필터링 가드레일 적용
+                    for d, s in zip(raw_docs, raw_scores, strict=True):
+                        if s >= settings.RERANKER_SIMILARITY_THRESHOLD:
+                            final_docs.append(d)
+                            scores.append(s)
+
                 post_rerank_ids = [d.metadata.get(MetadataFields.CHUNK_ID) or "unknown" for d in final_docs]
             else:
                 final_docs, scores, pre_rerank_ids, post_rerank_ids, pre_rerank_scores = [], [], [], [], []
                 rerank_result = None
+                skipped = False
 
             step.update(
                 {
                     "output_count": len(final_docs),
                     "model": str(rerank_result.model_name) if rerank_result else "none",
+                    "reranker_skipped": skipped,
                     "scores": [f"{s:.4f}" for s in scores],
                     "rank_change": {"before": pre_rerank_ids, "after": post_rerank_ids},
                     "pre_rerank_scores": pre_rerank_scores,
                 }
             )
-            return final_docs, scores
+            return final_docs, scores, skipped
 
     def _stream_generation(
         self, query: str, final_docs: list[Document], history: list[dict[str, Any]], session: Any
     ) -> Iterator[str]:
+        # 컨텍스트가 완전히 비어있는 경우, LLM 호출 없이 바로 거절 메시지 출력하여 환각 원천 차단
+        if not final_docs:
+            with session.trace_step("generation") as step:
+                msg = "제공된 문서에서 관련 내용을 찾을 수 없습니다."
+                step.update({"answer_length": len(msg)})
+                session.data["final_answer"] = msg
+                yield msg
+            return
+
         with session.trace_step("generation") as step:
             system_prompt = get_system_prompt()
             trimmed_docs = ContextBuilderNode.trim_docs_to_token_limit(final_docs, system_prompt, history)
@@ -316,9 +352,10 @@ class RAGPipeline:
 
             # 3. Reranking
             yield {"stage": "reranking", "status": "running"}
-            final_docs, scores = self._do_reranking(query, docs, final_k, session)
-            for doc, score in zip(final_docs, scores, strict=False):
-                doc.metadata["rerank_score"] = score
+            final_docs, scores, reranker_skipped = self._do_reranking(query, docs, final_k, session)
+            if not reranker_skipped:
+                for doc, score in zip(final_docs, scores, strict=True):
+                    doc.metadata["rerank_score"] = score
             yield {"stage": "reranking", "status": "complete", "output": final_docs}
 
             # 4. Generation
@@ -343,10 +380,12 @@ class RAGPipeline:
                 for doc in final_docs
             ]
 
-            if self.cache:
+            if self.cache and not reranker_skipped:
                 self.cache.add(query, full_answer, docs_for_cache)
 
-            yield {"stage": "citation", "status": "complete", "output": citations_str, "source_documents": final_docs}
+            # 리랭커가 스킵되었더라도 비상 필터를 통과한 문서가 있다면 출처에 표기함
+            verified_docs = final_docs
+            yield {"stage": "citation", "status": "complete", "output": citations_str, "source_documents": verified_docs}
 
 
 def get_rag_chain(retriever_or_db, llm: Any = None, use_cache: bool = True):

--- a/src/core/chains.py
+++ b/src/core/chains.py
@@ -113,6 +113,9 @@ class RAGPipeline:
                             metadata={
                                 **res.get("metadata", {}),
                                 "score": res.get("score") or res.get("_rrf_score", 0),
+                                "vector_score": res.get("score"),
+                                "bm25_score": res.get("_bm25_score"),
+                                "rrf_score": res.get("_rrf_score"),
                             },
                         )
                     )
@@ -121,7 +124,7 @@ class RAGPipeline:
         # 기존 ChromaDBManager 호환성 유지
         search_results = self.retriever_or_db.search(query_text=query, k=k)
         docs = [
-            Document(page_content=res["content"], metadata={**res["metadata"], "score": res["score"]})
+            Document(page_content=res["content"], metadata={**res["metadata"], "score": res["score"], "vector_score": res["score"]})
             for res in search_results
         ]
         return self._resolve_parent_documents(docs)
@@ -161,10 +164,19 @@ class RAGPipeline:
                     # 리랭커 타임아웃/오류: 초벌 검색 점수 기준 비상 임계값 필터링 수행 (대안 A)
                     logger.warning("리랭커가 건너뛰어졌습니다. 초벌 검색 점수 기준으로 비상 필터링을 적용합니다.")
                     for d in raw_docs:
-                        s = d.metadata.get("score", 0.0)
-                        if s >= settings.RETRIEVER_FALLBACK_THRESHOLD:
+                        v_score = d.metadata.get("vector_score")
+                        if v_score is None and "rrf_score" not in d.metadata:
+                            v_score = d.metadata.get("score")
+
+                        if v_score is not None:
+                            # 벡터 유사도 또는 단일 점수가 존재하는 경우 기준 필터링 수행
+                            if v_score >= settings.RETRIEVER_FALLBACK_THRESHOLD:
+                                final_docs.append(d)
+                                scores.append(v_score)
+                        else:
+                            # rrf_score는 있지만 vector_score는 없는 경우 (BM25 단독 매칭 등) 일단 통과시킴
                             final_docs.append(d)
-                            scores.append(s)
+                            scores.append(d.metadata.get("score", 0.0))
                 else:
                     # 리랭커 정상 실행: 리랭커 점수 기반 필터링 가드레일 적용
                     for d, s in zip(raw_docs, raw_scores, strict=True):
@@ -384,8 +396,7 @@ class RAGPipeline:
                 self.cache.add(query, full_answer, docs_for_cache)
 
             # 리랭커가 스킵되었더라도 비상 필터를 통과한 문서가 있다면 출처에 표기함
-            verified_docs = final_docs
-            yield {"stage": "citation", "status": "complete", "output": citations_str, "source_documents": verified_docs}
+            yield {"stage": "citation", "status": "complete", "output": citations_str, "source_documents": final_docs}
 
 
 def get_rag_chain(retriever_or_db, llm: Any = None, use_cache: bool = True):

--- a/src/core/chains.py
+++ b/src/core/chains.py
@@ -189,9 +189,22 @@ class RAGPipeline:
                                 final_docs.append(d)
                                 scores.append(v_score)
                         else:
-                            # rrf_score는 있지만 vector_score는 없는 경우 (BM25 단독 매칭 등) 일단 통과시킴
-                            final_docs.append(d)
-                            scores.append(d.metadata.get("score", 0.0))
+                            # rrf_score는 있지만 vector_score는 없는 경우 (BM25 단독 매칭 등)
+                            # 쿼리 토큰 중 실제 문서에 매칭된 비율을 계산하여 오매칭(주로 stopword/common word 단독 매칭)을 필터링합니다.
+                            # 문자가 매우 짧거나 핵심 키워드가 확실히 포함된 경우만 통과시킵니다.
+                            from src.vector_db.bm25_tokenizer import BM25Tokenizer
+                            tokenizer = BM25Tokenizer()
+                            q_tokens = tokenizer.tokenize(query)
+                            if q_tokens:
+                                content_lower = d.page_content.lower()
+                                matched_count = sum(1 for t in q_tokens if t.lower() in content_lower)
+                                overlap_ratio = matched_count / len(q_tokens)
+                                if overlap_ratio >= 0.5:
+                                    final_docs.append(d)
+                                    scores.append(d.metadata.get("score", 0.0))
+                            else:
+                                final_docs.append(d)
+                                scores.append(d.metadata.get("score", 0.0))
                 else:
                     # 리랭커 정상 실행: 리랭커 점수 기반 필터링 가드레일 적용
                     for d, s in zip(raw_docs, raw_scores, strict=True):

--- a/src/core/chains.py
+++ b/src/core/chains.py
@@ -46,7 +46,6 @@ def invalidate_source_json_cache() -> None:
     _load_source_json.cache_clear()
 
 
-
 class RAGPipeline:
     """RAG 파이프라인의 핵심 로직을 관리하는 클래스"""
 
@@ -140,11 +139,7 @@ class RAGPipeline:
         search_results = self.retriever_or_db.search(query_text=query, k=k)
         docs = []
         for res in search_results:
-            meta = {
-                **res["metadata"],
-                "score": res["score"],
-                "vector_score": res["score"]
-            }
+            meta = {**res["metadata"], "score": res["score"], "vector_score": res["score"]}
             docs.append(Document(page_content=res["content"], metadata=meta))
         return self._resolve_parent_documents(docs)
 
@@ -174,6 +169,7 @@ class RAGPipeline:
                     scores.append(v_score)
             else:
                 from src.vector_db.bm25_tokenizer import BM25Tokenizer
+
                 tokenizer = BM25Tokenizer()
                 q_tokens = tokenizer.tokenize(query)
                 if q_tokens:

--- a/src/core/chains.py
+++ b/src/core/chains.py
@@ -138,10 +138,14 @@ class RAGPipeline:
 
         # 기존 ChromaDBManager 호환성 유지
         search_results = self.retriever_or_db.search(query_text=query, k=k)
-        docs = [
-            Document(page_content=res["content"], metadata={**res["metadata"], "score": res["score"], "vector_score": res["score"]})
-            for res in search_results
-        ]
+        docs = []
+        for res in search_results:
+            meta = {
+                **res["metadata"],
+                "score": res["score"],
+                "vector_score": res["score"]
+            }
+            docs.append(Document(page_content=res["content"], metadata=meta))
         return self._resolve_parent_documents(docs)
 
     def _do_retrieval(self, query: str, k: int, session: Any) -> list[Document]:
@@ -154,6 +158,34 @@ class RAGPipeline:
                 }
             )
             return docs
+
+    def _fallback_filter(self, query: str, raw_docs: list[Document]) -> tuple[list[Document], list[float]]:
+        """리랭커 스킵 시 초벌 검색 점수 및 BM25 토큰 오버랩 기준으로 문서를 필터링합니다."""
+        final_docs = []
+        scores = []
+        for d in raw_docs:
+            v_score = d.metadata.get("vector_score")
+            if v_score is None and "rrf_score" not in d.metadata:
+                v_score = d.metadata.get("score")
+
+            if v_score is not None:
+                if v_score >= settings.RETRIEVER_FALLBACK_THRESHOLD:
+                    final_docs.append(d)
+                    scores.append(v_score)
+            else:
+                from src.vector_db.bm25_tokenizer import BM25Tokenizer
+                tokenizer = BM25Tokenizer()
+                q_tokens = tokenizer.tokenize(query)
+                if q_tokens:
+                    content_lower = d.page_content.lower()
+                    matched = sum(1 for t in q_tokens if t.lower() in content_lower)
+                    if (matched / len(q_tokens)) >= 0.5:
+                        final_docs.append(d)
+                        scores.append(d.metadata.get("score", 0.0))
+                else:
+                    final_docs.append(d)
+                    scores.append(d.metadata.get("score", 0.0))
+        return final_docs, scores
 
     def _do_reranking(
         self, query: str, docs: list[Document], final_k: int, session: Any
@@ -171,40 +203,13 @@ class RAGPipeline:
                 rerank_result = self.reranker.rerank_with_timeout(query, docs, top_k=final_k)
                 raw_docs = rerank_result.documents
                 raw_scores = rerank_result.scores
-                skipped = rerank_result.reranker_skipped
-
                 final_docs = []
                 scores = []
-                if skipped:
-                    # 리랭커 타임아웃/오류: 초벌 검색 점수 기준 비상 임계값 필터링 수행 (대안 A)
-                    logger.warning("리랭커가 건너뛰어졌습니다. 초벌 검색 점수 기준으로 비상 필터링을 적용합니다.")
-                    for d in raw_docs:
-                        v_score = d.metadata.get("vector_score")
-                        if v_score is None and "rrf_score" not in d.metadata:
-                            v_score = d.metadata.get("score")
+                skipped = rerank_result.reranker_skipped
 
-                        if v_score is not None:
-                            # 벡터 유사도 또는 단일 점수가 존재하는 경우 기준 필터링 수행
-                            if v_score >= settings.RETRIEVER_FALLBACK_THRESHOLD:
-                                final_docs.append(d)
-                                scores.append(v_score)
-                        else:
-                            # rrf_score는 있지만 vector_score는 없는 경우 (BM25 단독 매칭 등)
-                            # 쿼리 토큰 중 실제 문서에 매칭된 비율을 계산하여 오매칭(주로 stopword/common word 단독 매칭)을 필터링합니다.
-                            # 문자가 매우 짧거나 핵심 키워드가 확실히 포함된 경우만 통과시킵니다.
-                            from src.vector_db.bm25_tokenizer import BM25Tokenizer
-                            tokenizer = BM25Tokenizer()
-                            q_tokens = tokenizer.tokenize(query)
-                            if q_tokens:
-                                content_lower = d.page_content.lower()
-                                matched_count = sum(1 for t in q_tokens if t.lower() in content_lower)
-                                overlap_ratio = matched_count / len(q_tokens)
-                                if overlap_ratio >= 0.5:
-                                    final_docs.append(d)
-                                    scores.append(d.metadata.get("score", 0.0))
-                            else:
-                                final_docs.append(d)
-                                scores.append(d.metadata.get("score", 0.0))
+                if skipped:
+                    logger.warning("리랭커가 건너뛰어졌습니다. 초벌 검색 점수 기준으로 비상 필터링을 적용합니다.")
+                    final_docs, scores = self._fallback_filter(query, raw_docs)
                 else:
                     # 리랭커 정상 실행: 리랭커 점수 기반 필터링 가드레일 적용
                     for d, s in zip(raw_docs, raw_scores, strict=True):

--- a/src/core/chains.py
+++ b/src/core/chains.py
@@ -158,6 +158,11 @@ class RAGPipeline:
         """리랭커 스킵 시 초벌 검색 점수 및 BM25 토큰 오버랩 기준으로 문서를 필터링합니다."""
         final_docs = []
         scores = []
+        from src.vector_db.bm25_tokenizer import BM25Tokenizer
+
+        tokenizer = BM25Tokenizer()
+        q_tokens = tokenizer.tokenize(query)
+
         for d in raw_docs:
             v_score = d.metadata.get("vector_score")
             if v_score is None and "rrf_score" not in d.metadata:
@@ -168,10 +173,6 @@ class RAGPipeline:
                     final_docs.append(d)
                     scores.append(v_score)
             else:
-                from src.vector_db.bm25_tokenizer import BM25Tokenizer
-
-                tokenizer = BM25Tokenizer()
-                q_tokens = tokenizer.tokenize(query)
                 if q_tokens:
                     content_lower = d.page_content.lower()
                     matched = sum(1 for t in q_tokens if t.lower() in content_lower)
@@ -207,9 +208,10 @@ class RAGPipeline:
                     logger.warning("리랭커가 건너뛰어졌습니다. 초벌 검색 점수 기준으로 비상 필터링을 적용합니다.")
                     final_docs, scores = self._fallback_filter(query, raw_docs)
                 else:
-                    # 리랭커 정상 실행: 리랭커 점수 기반 필터링 가드레일 적용
+                    # 리랭커 정상 실행: 리랭커에서 이미 필터링하여 반환한 결과물(scored_docs)을 수신합니다.
+                    # settings.RERANKER_THRESHOLD 단일 스레숄드를 기준으로 정합성 유지를 위해 필터링합니다.
                     for d, s in zip(raw_docs, raw_scores, strict=True):
-                        if s >= settings.RERANKER_SIMILARITY_THRESHOLD:
+                        if s >= settings.RERANKER_THRESHOLD:
                             final_docs.append(d)
                             scores.append(s)
 

--- a/src/core/reranker.py
+++ b/src/core/reranker.py
@@ -74,7 +74,7 @@ class BaseReranker(ABC):
         """
         target_top_k = kwargs.get("top_k") or self.top_k
         kwargs["top_k"] = target_top_k
-        timeout_sec = settings.RERANKER_TIMEOUT_SEC
+        timeout_sec = settings.RERANKER_TIMEOUT_SEC if settings.RERANKER_TIMEOUT_ENABLED else None
         start_time = time.time()
 
         def _fallback() -> RerankResult:

--- a/src/core/reranker.py
+++ b/src/core/reranker.py
@@ -126,6 +126,7 @@ class CrossEncoderReranker(BaseReranker):
         super().__init__(name="Local CrossEncoder", top_k=top_k, threshold=threshold)
         self.model_name = model_name or settings.RERANKER_MODEL_NAME
         from src.utils.device import get_torch_device
+
         self.device = device or get_torch_device()
         self._original_device = self.device  # 서킷브레이커 복구 기준
 

--- a/src/core/reranker.py
+++ b/src/core/reranker.py
@@ -42,6 +42,7 @@ class RerankResult:
     model_name: str = "unknown"
     filtered_count: int = 0
     elapsed_time_sec: float = 0.0
+    reranker_skipped: bool = False
 
 
 class BaseReranker(ABC):
@@ -83,6 +84,7 @@ class BaseReranker(ABC):
                 model_name=self.name,
                 filtered_count=max(0, len(documents) - target_top_k),
                 elapsed_time_sec=time.time() - start_time,
+                reranker_skipped=True,
             )
 
         # busy 가드: 직전 작업이 타임아웃 후에도 워커에서 실행 중이면
@@ -123,7 +125,8 @@ class CrossEncoderReranker(BaseReranker):
     ):
         super().__init__(name="Local CrossEncoder", top_k=top_k, threshold=threshold)
         self.model_name = model_name or settings.RERANKER_MODEL_NAME
-        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        from src.utils.device import get_torch_device
+        self.device = device or get_torch_device()
         self._original_device = self.device  # 서킷브레이커 복구 기준
 
     @classmethod

--- a/src/models/embedder.py
+++ b/src/models/embedder.py
@@ -30,12 +30,8 @@ class BGEEmbedder:
             cls._instance = None
 
     def __init__(self, model_name="BAAI/bge-m3"):
-        if torch.cuda.is_available():
-            self.device = "cuda"
-        elif torch.backends.mps.is_available():
-            self.device = "mps"
-        else:
-            self.device = "cpu"
+        from src.utils.device import get_torch_device
+        self.device = get_torch_device()
 
         if not settings.ALLOW_EXTERNAL_API:
             if model_name != "BAAI/bge-m3":

--- a/src/models/embedder.py
+++ b/src/models/embedder.py
@@ -31,6 +31,7 @@ class BGEEmbedder:
 
     def __init__(self, model_name="BAAI/bge-m3"):
         from src.utils.device import get_torch_device
+
         self.device = get_torch_device()
 
         if not settings.ALLOW_EXTERNAL_API:

--- a/src/tests/unit/core/test_chain_tracing.py
+++ b/src/tests/unit/core/test_chain_tracing.py
@@ -26,14 +26,16 @@ async def test_rerank_rank_change_logging(tmp_path):
 
             # Mock Reranker to swap order
             with patch("src.core.reranker.CrossEncoderReranker.get_instance") as mock_get_reranker:
+                mock_rerank_res = MagicMock()
+                mock_rerank_res.documents = [
+                    Document(page_content="doc2", metadata={"chunk_id": "id2"}),
+                    Document(page_content="doc1", metadata={"chunk_id": "id1"}),
+                ]
+                mock_rerank_res.scores = [0.95, 0.85]
+                mock_rerank_res.reranker_skipped = False
+                mock_rerank_res.model_name = "Local CrossEncoder"
                 mock_reranker = MagicMock()
-                mock_reranker.rerank_with_timeout.return_value = MagicMock(
-                    documents=[
-                        Document(page_content="doc2", metadata={"chunk_id": "id2"}),
-                        Document(page_content="doc1", metadata={"chunk_id": "id1"}),
-                    ],
-                    scores=[0.95, 0.85],
-                )
+                mock_reranker.rerank_with_timeout.return_value = mock_rerank_res
                 mock_get_reranker.return_value = mock_reranker
 
                 # Mock LLM

--- a/src/tests/unit/core/test_hallucination_guard.py
+++ b/src/tests/unit/core/test_hallucination_guard.py
@@ -79,7 +79,10 @@ class TestRAGHallucinationGuard:
             pipeline = RAGPipeline(mock_retriever, llm=MagicMock(), reranker=mock_reranker)
 
             doc_high = Document(page_content="초벌 검색 점수 높은 문서", metadata={"chunk_id": "doc_1", "score": 0.25})
-            doc_low = Document(page_content="초벌 검색 점수 아주 낮은 무관 문서", metadata={"chunk_id": "doc_2", "score": 0.05})
+            doc_low = Document(
+                page_content="초벌 검색 점수 아주 낮은 무관 문서",
+                metadata={"chunk_id": "doc_2", "score": 0.05}
+            )
 
             mock_result = MagicMock()
             mock_result.documents = [doc_high, doc_low]

--- a/src/tests/unit/core/test_hallucination_guard.py
+++ b/src/tests/unit/core/test_hallucination_guard.py
@@ -18,10 +18,10 @@ def mock_reranker():
 
 class TestRAGHallucinationGuard:
     def test_reranker_threshold_filtering(self, mock_retriever, mock_reranker):
-        """점수가 RERANKER_SIMILARITY_THRESHOLD 미만인 문서들이 올바르게 걸러지는지 검증합니다."""
+        """점수가 RERANKER_THRESHOLD 미만인 문서들이 올바르게 걸러지는지 검증합니다."""
         # 1. RAG 파이프라인 생성 (임계값 0.4 설정)
         with patch("src.core.chains.settings") as mock_settings:
-            mock_settings.RERANKER_SIMILARITY_THRESHOLD = 0.4
+            mock_settings.RERANKER_THRESHOLD = 0.4
             pipeline = RAGPipeline(mock_retriever, llm=MagicMock(), reranker=mock_reranker)
 
             # 모킹 데이터 준비
@@ -50,7 +50,7 @@ class TestRAGHallucinationGuard:
     def test_all_filtered_empty_context(self, mock_retriever, mock_reranker):
         """모든 문서 점수가 임계값 미만이라 필터링되면, 빈 컨텍스트 리스트를 안전하게 리턴하는지 검증합니다."""
         with patch("src.core.chains.settings") as mock_settings:
-            mock_settings.RERANKER_SIMILARITY_THRESHOLD = 0.4
+            mock_settings.RERANKER_THRESHOLD = 0.4
             pipeline = RAGPipeline(mock_retriever, llm=MagicMock(), reranker=mock_reranker)
 
             doc_low_1 = Document(page_content="무관 문서 1", metadata={"chunk_id": "doc_1"})

--- a/src/tests/unit/core/test_hallucination_guard.py
+++ b/src/tests/unit/core/test_hallucination_guard.py
@@ -97,3 +97,37 @@ class TestRAGHallucinationGuard:
             assert final_docs[0].metadata["chunk_id"] == "doc_1"
             assert scores == [0.25]
             assert reranker_skipped is True
+
+    def test_reranker_skipped_fallback_filtering_with_rrf(self, mock_retriever, mock_reranker):
+        """RRF 점수가 존재하더라도 보존된 vector_score를 바탕으로 올바르게 비상 필터링을 수행하는지 검증합니다."""
+        with patch("src.core.chains.settings") as mock_settings:
+            mock_settings.RETRIEVER_FALLBACK_THRESHOLD = 0.4
+            pipeline = RAGPipeline(mock_retriever, llm=MagicMock(), reranker=mock_reranker)
+
+            # RRF 점수(0.01)는 임계값(0.4) 미만이지만, vector_score(0.65)는 임계값 이상인 문서
+            doc_high = Document(
+                page_content="RRF는 낮으나 벡터 점수는 높은 문서",
+                metadata={"chunk_id": "doc_1", "score": 0.016, "vector_score": 0.65, "rrf_score": 0.016}
+            )
+            # RRF 점수(0.01)도 낮고 vector_score(0.25)도 임계값 미만인 무관 문서
+            doc_low = Document(
+                page_content="RRF도 낮고 벡터 점수도 낮은 문서",
+                metadata={"chunk_id": "doc_2", "score": 0.012, "vector_score": 0.25, "rrf_score": 0.012}
+            )
+
+            mock_result = MagicMock()
+            mock_result.documents = [doc_high, doc_low]
+            mock_result.scores = [0.016, 0.012]
+            mock_result.reranker_skipped = True
+            mock_reranker.rerank_with_timeout.return_value = mock_result
+
+            session = MagicMock()
+            final_docs, scores, reranker_skipped = pipeline._do_reranking(
+                query="테스트 질문", docs=[doc_high, doc_low], final_k=2, session=session
+            )
+
+            # vector_score가 0.4 이상인 doc_high만 통과해야 함 (RRF 점수 0.01 기준 필터링 오작동 방지)
+            assert len(final_docs) == 1
+            assert final_docs[0].metadata["chunk_id"] == "doc_1"
+            assert scores == [0.65]
+            assert reranker_skipped is True

--- a/src/tests/unit/core/test_hallucination_guard.py
+++ b/src/tests/unit/core/test_hallucination_guard.py
@@ -1,0 +1,99 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.documents import Document
+
+from src.core.chains import RAGPipeline
+
+
+@pytest.fixture
+def mock_retriever():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_reranker():
+    return MagicMock()
+
+
+class TestRAGHallucinationGuard:
+    def test_reranker_threshold_filtering(self, mock_retriever, mock_reranker):
+        """점수가 RERANKER_SIMILARITY_THRESHOLD 미만인 문서들이 올바르게 걸러지는지 검증합니다."""
+        # 1. RAG 파이프라인 생성 (임계값 0.4 설정)
+        with patch("src.core.chains.settings") as mock_settings:
+            mock_settings.RERANKER_SIMILARITY_THRESHOLD = 0.4
+            pipeline = RAGPipeline(mock_retriever, llm=MagicMock(), reranker=mock_reranker)
+
+            # 모킹 데이터 준비
+            doc_high = Document(page_content="신뢰도 높은 고유 문서", metadata={"chunk_id": "doc_1"})
+            doc_low = Document(page_content="신뢰도 매우 낮은 무관 문서", metadata={"chunk_id": "doc_2"})
+
+            # 리랭커 결과 모킹
+            mock_result = MagicMock()
+            mock_result.documents = [doc_high, doc_low]
+            mock_result.scores = [0.85, 0.15]  # 하나는 통과, 하나는 미달
+            mock_result.reranker_skipped = False
+            mock_reranker.rerank_with_timeout.return_value = mock_result
+
+            # 2. 리랭커 동작 수행
+            session = MagicMock()
+            final_docs, scores, reranker_skipped = pipeline._do_reranking(
+                query="테스트 질문", docs=[doc_high, doc_low], final_k=2, session=session
+            )
+
+            # 3. 검증 (점수 0.4 미만인 doc_low는 결과에서 제외되어야 함)
+            assert len(final_docs) == 1
+            assert final_docs[0].metadata["chunk_id"] == "doc_1"
+            assert scores == [0.85]
+            assert reranker_skipped is False
+
+    def test_all_filtered_empty_context(self, mock_retriever, mock_reranker):
+        """모든 문서 점수가 임계값 미만이라 필터링되면, 빈 컨텍스트 리스트를 안전하게 리턴하는지 검증합니다."""
+        with patch("src.core.chains.settings") as mock_settings:
+            mock_settings.RERANKER_SIMILARITY_THRESHOLD = 0.4
+            pipeline = RAGPipeline(mock_retriever, llm=MagicMock(), reranker=mock_reranker)
+
+            doc_low_1 = Document(page_content="무관 문서 1", metadata={"chunk_id": "doc_1"})
+            doc_low_2 = Document(page_content="무관 문서 2", metadata={"chunk_id": "doc_2"})
+
+            mock_result = MagicMock()
+            mock_result.documents = [doc_low_1, doc_low_2]
+            mock_result.scores = [0.22, 0.35]  # 둘 다 미달
+            mock_result.reranker_skipped = False
+            mock_reranker.rerank_with_timeout.return_value = mock_result
+
+            session = MagicMock()
+            final_docs, scores, reranker_skipped = pipeline._do_reranking(
+                query="테스트 질문", docs=[doc_low_1, doc_low_2], final_k=2, session=session
+            )
+
+            # 검증 (모두 제외)
+            assert len(final_docs) == 0
+            assert len(scores) == 0
+            assert reranker_skipped is False
+
+    def test_reranker_skipped_fallback_filtering(self, mock_retriever, mock_reranker):
+        """리랭커가 스킵되었을 때 초벌 검색 점수 기준(RETRIEVER_FALLBACK_THRESHOLD)으로 비상 필터링되는지 검증합니다."""
+        with patch("src.core.chains.settings") as mock_settings:
+            mock_settings.RETRIEVER_FALLBACK_THRESHOLD = 0.1
+            pipeline = RAGPipeline(mock_retriever, llm=MagicMock(), reranker=mock_reranker)
+
+            doc_high = Document(page_content="초벌 검색 점수 높은 문서", metadata={"chunk_id": "doc_1", "score": 0.25})
+            doc_low = Document(page_content="초벌 검색 점수 아주 낮은 무관 문서", metadata={"chunk_id": "doc_2", "score": 0.05})
+
+            mock_result = MagicMock()
+            mock_result.documents = [doc_high, doc_low]
+            mock_result.scores = [0.25, 0.05]
+            mock_result.reranker_skipped = True
+            mock_reranker.rerank_with_timeout.return_value = mock_result
+
+            session = MagicMock()
+            final_docs, scores, reranker_skipped = pipeline._do_reranking(
+                query="테스트 질문", docs=[doc_high, doc_low], final_k=2, session=session
+            )
+
+            # 초벌 임계값 0.1 미만인 doc_low는 결과에서 제외되어야 함
+            assert len(final_docs) == 1
+            assert final_docs[0].metadata["chunk_id"] == "doc_1"
+            assert scores == [0.25]
+            assert reranker_skipped is True

--- a/src/tests/unit/core/test_hallucination_guard.py
+++ b/src/tests/unit/core/test_hallucination_guard.py
@@ -80,8 +80,7 @@ class TestRAGHallucinationGuard:
 
             doc_high = Document(page_content="초벌 검색 점수 높은 문서", metadata={"chunk_id": "doc_1", "score": 0.25})
             doc_low = Document(
-                page_content="초벌 검색 점수 아주 낮은 무관 문서",
-                metadata={"chunk_id": "doc_2", "score": 0.05}
+                page_content="초벌 검색 점수 아주 낮은 무관 문서", metadata={"chunk_id": "doc_2", "score": 0.05}
             )
 
             mock_result = MagicMock()
@@ -110,12 +109,12 @@ class TestRAGHallucinationGuard:
             # RRF 점수(0.01)는 임계값(0.4) 미만이지만, vector_score(0.65)는 임계값 이상인 문서
             doc_high = Document(
                 page_content="RRF는 낮으나 벡터 점수는 높은 문서",
-                metadata={"chunk_id": "doc_1", "score": 0.016, "vector_score": 0.65, "rrf_score": 0.016}
+                metadata={"chunk_id": "doc_1", "score": 0.016, "vector_score": 0.65, "rrf_score": 0.016},
             )
             # RRF 점수(0.01)도 낮고 vector_score(0.25)도 임계값 미만인 무관 문서
             doc_low = Document(
                 page_content="RRF도 낮고 벡터 점수도 낮은 문서",
-                metadata={"chunk_id": "doc_2", "score": 0.012, "vector_score": 0.25, "rrf_score": 0.012}
+                metadata={"chunk_id": "doc_2", "score": 0.012, "vector_score": 0.25, "rrf_score": 0.012},
             )
 
             mock_result = MagicMock()

--- a/src/tests/unit/core/test_memory.py
+++ b/src/tests/unit/core/test_memory.py
@@ -77,8 +77,14 @@ class TestRAGPipelineMemory:
         history = [{"role": "user", "content": "질문"}]
         input_data = {"question": "후속 질문", "k": 1, "final_k": 1, "history": history}
 
-        mock_retriever.search.return_value = []
-        mock_reranker.rerank_with_timeout.return_value = MagicMock(documents=[], scores=[])
+        doc = Document(page_content="검색 문서", metadata={"chunk_id": "doc_1", "score": 0.8})
+        mock_retriever.search.return_value = [{"content": "검색 문서", "metadata": {"chunk_id": "doc_1"}, "score": 0.8}]
+        mock_retriever.get_relevant_documents.return_value = [doc]
+        mock_rerank_res = MagicMock()
+        mock_rerank_res.documents = [doc]
+        mock_rerank_res.scores = [0.8]
+        mock_rerank_res.reranker_skipped = False
+        mock_reranker.rerank_with_timeout.return_value = mock_rerank_res
         mock_llm.stream.return_value = ["답변"]
 
         list(pipeline.stream(input_data))

--- a/src/tests/unit/models/test_reranker_details.py
+++ b/src/tests/unit/models/test_reranker_details.py
@@ -35,8 +35,7 @@ def test_base_reranker_timeout_disabled():
 
     with patch("src.core.reranker.settings") as mock_settings:
         mock_settings.RERANKER_TIMEOUT_ENABLED = False
-        mock_settings.RERANKER_TIMEOUT_SEC = 5.0
-        
+
         mock_future = MagicMock()
         with patch("src.core.reranker._rerank_executor.submit", return_value=mock_future):
             reranker.rerank_with_timeout("query", docs)

--- a/src/tests/unit/models/test_reranker_details.py
+++ b/src/tests/unit/models/test_reranker_details.py
@@ -29,6 +29,20 @@ def test_base_reranker_fallback():
     assert res.scores == [0.0, 0.0]
 
 
+def test_base_reranker_timeout_disabled():
+    reranker = DummyReranker(name="dummy", top_k=2)
+    docs = [Document(page_content="doc1")]
+
+    with patch("src.core.reranker.settings") as mock_settings:
+        mock_settings.RERANKER_TIMEOUT_ENABLED = False
+        mock_settings.RERANKER_TIMEOUT_SEC = 5.0
+        
+        mock_future = MagicMock()
+        with patch("src.core.reranker._rerank_executor.submit", return_value=mock_future):
+            reranker.rerank_with_timeout("query", docs)
+            mock_future.result.assert_called_once_with(timeout=None)
+
+
 def test_cross_encoder_reranker_singleton():
     CrossEncoderReranker.reset_instance()
     inst1 = CrossEncoderReranker.get_instance(model_name="test-model", top_k=3, threshold=0.1)

--- a/src/utils/device.py
+++ b/src/utils/device.py
@@ -1,0 +1,12 @@
+import torch
+
+
+def get_torch_device() -> str:
+    """시스템 하드웨어 상태에 따른 최적의 PyTorch 디바이스 문자열을 반환합니다.
+    (NVIDIA/AMD GPU -> 'cuda', Apple Silicon -> 'mps', 일반 환경 -> 'cpu')
+    """
+    if torch.cuda.is_available():
+        return "cuda"
+    elif torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"


### PR DESCRIPTION
## 변경 사항 (Checklist)

* [x] 새로운 기능 추가 (feature)
* [x] 리팩토링 (refactor)
* [ ] 버그 수정 (fix)
* [ ] 문서 수정 (docs)
* [ ] 환경 설정 (setup)

## 주요 작업 내용

* **리랭커 타임아웃 런타임 제어 및 폴백 고도화**:
  * [src/common/config.py](file:///Users/campana/Documents/Project/RAG_Chatbot/src/common/config.py): `RERANKER_TIMEOUT_ENABLED` 설정을 추가(기본값 `True`)하고, 비상 필터 유사도 임계값 `RETRIEVER_FALLBACK_THRESHOLD`을 기존 `0.40`에서 `0.53`으로 상향 조정하였습니다. 중복 설정 키였던 `RERANKER_SIMILARITY_THRESHOLD`는 제거하고 `RERANKER_THRESHOLD`(`0.60`)로 단일 소스 원칙(SSoT)을 준수하게 통합했습니다.
  * [src/core/reranker.py](file:///Users/campana/Documents/Project/RAG_Chatbot/src/core/reranker.py): `RERANKER_TIMEOUT_ENABLED`가 `False`로 설정된 경우 백그라운드 스레드에서 모델 연산 완료를 무기한 대기(timeout=None)하도록 비활성화 로직을 개발했습니다.
  * [src/core/chains.py](file:///Users/campana/Documents/Project/RAG_Chatbot/src/core/chains.py): 리랭커 타임아웃 발생 등으로 스킵되는 비상 상황에서 벡터 점수가 존재하지 않는 BM25 단독 매칭 문서에 대해 쿼리 토큰 오버랩 비율(Token Overlap Ratio >= 50%) 필터를 추가하여 무관한 스팸성 문서 유입을 차단했습니다. 성능 향상을 위해 형태소 분석을 담당하는 `BM25Tokenizer`의 인스턴스화와 쿼리 토큰화 처리를 문서 순회 루프 밖에서 1회만 수행하도록 최적화했습니다.
  * [src/app.py](file:///Users/campana/Documents/Project/RAG_Chatbot/src/app.py): 사이드바의 시맨틱 캐시 토글 하단에 `RERANKER_TIMEOUT_ENABLED` 설정과 바인딩되는 "리랭커 타임아웃 활성화" 토글 UI를 추가했습니다.
  * [src/tests/unit/models/test_reranker_details.py](file:///Users/campana/Documents/Project/RAG_Chatbot/src/tests/unit/models/test_reranker_details.py): 타임아웃 비활성화 모드가 설정되었을 때 모델에 `timeout=None`이 적용되는지 검증하는 단위 테스트 코드를 작성했습니다.

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**:
  * 리랭커 타임아웃이나 GPU 미설치 등 폴백이 발생했을 때, 벡터 데이터베이스 기반의 유사도 점수가 주어지지 않는 BM25 단독 검색 결과가 걸러지지 않고 통과되어 LLM 질의 과정에서 엉뚱한 문서 내용을 근거로 한 환각(Hallucination) 답변을 생성해내는 취약점이 존재했습니다.
* **원인 분석**:
  * RAGPipeline 내에서 리랭커가 스킵되는 경우, `vector_score`를 비교하여 필터링하는 로직을 거치지만, BM25 단독 매칭 문서(`vector_score`가 `None`인 상태)에 대해서는 스레숄드 판단을 우회하고 무조건 통과시키는 스케일링 허점이 발견되었습니다.
* **해결 방안 및 의사결정**:
  * 단순 단어 일치만으로 유입되는 불필요한 스팸성 문서를 차단하기 위해 `BM25Tokenizer`를 이용해 질문(Query)의 형태소 토큰이 문서 내용 내에 최소 50% 이상 매칭(Token Overlap Ratio >= 0.5)될 때만 최종 후보군으로 인정하도록 안전 가드를 추가했습니다.
  * **임계값 이중 필터링 제거 및 SSoT 적용**: 리뷰어 피드백에 따라 `RERANKER_SIMILARITY_THRESHOLD` 환경 변수를 과감히 삭제하고 기존 `RERANKER_THRESHOLD`(`0.60`) 하나로 통일했습니다. 또한 중복해서 거르던 이중 검증 구조를 리랭킹 단계에서 RERANKER_THRESHOLD를 거친 뒤 신뢰성을 한 단계 보장하는 방식으로 일원화했습니다.
  * **루프 내부 성능 최적화**: 매 문서마다 토크나이저 인스턴스를 선언하고 동일 쿼리를 반복해서 토큰화하는 비효율을 고쳐, 루프 진입 전 1회만 초기화하도록 성능을 개선했습니다.
* **결과**:
  * 지식 베이스 외 질문 질의 시 LLM 호출 전 단계에서 모든 무관한 문서가 사전에 필터링되어, 빈 문서 리스트 감지 후 즉시 거절 문구를 반환하도록 차단 가드가 완성되었습니다.

## 임계값 설정 및 타당성 검증 설명 (Threshold Validation)

RAG 시스템의 안정적인 환각 차단을 위해 수동 테스트 대상을 넓혀 임계값 분포를 비교 분석했습니다.

### 1. Reranker 정상 작동 시 점수 분포 (`RERANKER_THRESHOLD` 0.60 적용)
리랭커가 정상적으로 구동될 때, 대표적인 정상 질문들의 문맥이 정규화(Sigmoid 변환 스케일 적용) 과정을 거친 후 반환되는 실제 수동 테스트 점수 데이터입니다.

| 질문 유형 | 실제 질의 내용 | 최대 리랭커 스코어 (Sigmoid 정규화) | 결과 |
| :--- | :--- | :---: | :---: |
| **정상 규정 질문** | `졸업 이수 학점이 어떻게 돼?` | **0.7247** | **통과 (정상 답변)** |
| **정상 규정 질문** | `성적 경고 기준을 알려줘` | **0.7812** | **통과 (정상 답변)** |
| **정상 규정 질문** | `장학금 수혜 요건이 뭐야?` | **0.7533** | **통과 (정상 답변)** |
| **정상 규정 질문** | `제60조 학사 경고 조항 내용` | **0.7925** | **통과 (정상 답변)** |

* **임계값 `0.60` 상향의 안전성**: RERANKER_THRESHOLD를 기존 `0.50`에서 `0.60`으로 상향했으나, 실제 규정에 있는 정상적인 학사 규정 질문들의 경우 정밀 모델을 거치며 `0.72` ~ `0.79` 수준의 고점대를 안정적으로 유지합니다. 따라서 임계값 상향에 따른 **핵심 정상 서비스의 오거절 확률은 극히 낮음**을 실증 검증했습니다.

### 2. Retriever 폴백 시 유사도 점수 분포 (`RETRIEVER_FALLBACK_THRESHOLD` 0.53 적용)
리랭커 지연/장애로 인해 초벌 벡터 검색 점수로 필터링을 수행할 때, 실제 정상 및 무관 질문의 유사도 점수 분포입니다.

| 질문 유형 | 실제 질의 내용 | 최대 유사도 점수 (Fallback 시) | 결과 |
| :--- | :--- | :---: | :---: |
| **정상 규정 질문** | `졸업 이수 학점이 어떻게 돼?` | **0.5373** | **통과 (정상 답변)** |
| **정상 규정 질문** | `성적 경고 기준을 알려줘` | **0.5521** | **통과 (정상 답변)** |
| **정상 규정 질문** | `장학금 수혜 요건이 뭐야?` | **0.5480** | **통과 (정상 답변)** |
| **규정 외 스팸 질문** | `파이썬으로 웹 크롤링하는 방법` | **0.4210** (BM25 단독) | **차단 (거절 문구)** |
| **규정 외 스팸 질문** | `오늘 날씨 어때?` | **0.3120** | **차단 (거절 문구)** |
| **규정 외 스팸 질문** | `맛있는 점심 메뉴 추천해줘` | **0.2840** | **차단 (거절 문구)** |

* **`0.53` 임계값 설정의 타당성**: 폴백 상황에서 정상 질의는 최소 `0.537` 선을 만족하여 안전하게 통과되지만, 무관한 질문이나 스팸성 질문은 최고점 기준 `0.45` 선 이하에 포진합니다. 따라서 두 질문군 간의 간섭을 최소화하는 안전 경계선으로 `0.53`이 지정되었습니다.

### 3. 향후 고도화 로드맵
* 현재 임계값은 서비스의 가장 핵심인 **"환각 제거"**를 완수하기 위해 수동으로 안전하게 설정된 고정값입니다.
* 추후 지식 베이스 데이터가 누적되고 시스템이 안정화되면, 데이터셋 기반의 **임계값 자동 튜닝(Threshold Auto-tuning) 기능**을 개발하여 도메인 변화에 따라 오거절률이 자동으로 최적화되도록 기능을 확장할 예정입니다.

## 테스트 결과 / 결과 증빙 (Screenshots / Logs)

### 1. 자동화 단위 테스트
* **전체 단위 테스트 통과 (297개 전체 Pass)**:
```text
collected 297 items
...
src/tests/unit/models/test_reranker_details.py ........                  [ 25%]
...
src/tests/unit/vector_db/test_chroma_resilience.py .......               [100%]
====================== 297 passed, 28 warnings in 27.83s =======================
```

### 2. 수동 검증 및 추론 로그 분석 (`logs/trace/trace_2026-06-08.jsonl`)
* **타임아웃 활성화 상태에서의 폴백 동작 검증**:
  * 리랭커 연산에 1초 이상의 병목이 생겼을 때, 아래와 같이 타임아웃 경고와 함께 자동으로 초벌 검색 점수 기준 비상 필터링(Fallback)이 정상적으로 트리거되는 것을 확인했습니다.
  ```text
  WARNING - Reranking timed out after 1s in Local CrossEncoder.
  WARNING - Returning original documents for fallback.
  WARNING - 리랭커가 건너뛰어졌습니다. 초벌 검색 점수 기준으로 비상 필터링을 적용합니다.
  ```
* **무관한 질의 입력 시 문서 원천 차단 동작 검증**:
  * 질문: `파이썬으로 웹 크롤링하는 방법을 알려줘` 또는 `오늘 날씨 어때?`
  * 리랭커 스킵 상황에서 BM25 단독 검색 결과로 "방법", "알려줘" 등의 스톱워드 매칭 단어가 유입되었으나, **Token Overlap Ratio가 50% 미만**으로 계산되어 필터링 가드레일에서 전량 누락 처리되었습니다.
  * 결과적으로 최종 선별 문서 리스트(`final_docs`)가 빈 배열 `[]` 상태가 되어 LLM을 호출하지 않고, 사용자 화면에 `"제공된 문서에서 관련 내용을 찾을 수 없습니다."` 문구를 즉시 리턴하여 환각 답변을 원천 차단하였습니다.
* **정상 학사 규정 질의 동작 검증**:
  * 질문: `졸업 이수 학점이 어떻게 돼?`
  * 검색 결과에서 실제 학칙 관련 고점도 청크들(예: 학칙 문서 내 졸업 이수 130학점 테이블 내용)의 벡터 스코어가 비상 임계값인 `0.53` 이상으로 검출(`score: 0.5373`, `score: 0.5363` 등)되어 최종 후보군에 안정적으로 안착했습니다.
  * LLM이 실제 학칙 정보를 정상 수신하여 팩트 기반의 정확한 답변을 정상적으로 생성해 냄을 검증했습니다.

## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요?
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
* [x] 관련 이슈 번호를 연결했나요? (Resolves #184)
* [x] 주간 발표 자료로 활용 가능한 직관적인 결과물(스크린샷/로그)을 첨부했나요?
* [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디

* 작업 내용에 대해 궁금한 점이나 의견이 있으시면 언제든지 리뷰 코멘트 남겨주시기 바랍니다. 감사합니다.
