### PR TITLE
feat(security): 앱/관리자 접근 인증 게이트 추가 (#133)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,14 @@ DB_PATH=./vector_db
 # REDIS_URL=redis://redis:6379/0
 # REDIS_SESSION_TTL_SEC=86400
 
+# 6. 접근 인증 (#133) — 값 설정 시에만 비밀번호 게이트 활성, 미설정이면 게이트 없음
+# APP_PASSWORD: 앱 전체 접속 비밀번호
+# APP_PASSWORD=your_secure_app_password
+# ADMIN_PASSWORD: 관리자 패널 별도 비밀번호 (APP_PASSWORD와 다르게 설정 권장)
+# ADMIN_PASSWORD=your_secure_admin_password
+#
+# 주의: .env 파일은 절대 커밋하지 말 것 (.gitignore 포함 필수).
+
 # 6. LangSmith Tracing (선택사항)
 # LANGSMITH_TRACING=true
 # LANGSMITH_ENDPOINT=https://api.smith.langchain.com

--- a/.env.example
+++ b/.env.example
@@ -60,11 +60,14 @@ DB_PATH=./vector_db
 # REDIS_URL=redis://redis:6379/0
 # REDIS_SESSION_TTL_SEC=86400
 
-# 6. 접근 인증 (#133) — 값 설정 시에만 비밀번호 게이트 활성, 미설정이면 게이트 없음
-# APP_PASSWORD: 앱 전체 접속 비밀번호
-# APP_PASSWORD=your_secure_app_password
-# ADMIN_PASSWORD: 관리자 패널 별도 비밀번호 (APP_PASSWORD와 다르게 설정 권장)
-# ADMIN_PASSWORD=your_secure_admin_password
+# 6. 접근 인증 (#133) — bcrypt 해시 설정 시에만 게이트 활성, 미설정이면 게이트 없음
+# 평문이 아니라 bcrypt 해시를 저장한다. 해시 생성:
+#   python -c "import bcrypt; print(bcrypt.hashpw(b'YOUR_PASSWORD', bcrypt.gensalt()).decode())"
+# 해시값에 $ 가 들어가므로 .env에서는 작은따옴표로 감싼다($ 보간 방지).
+# APP_PASSWORD_HASH: 앱 전체 접속 게이트
+# APP_PASSWORD_HASH='$2b$12$...'
+# ADMIN_PASSWORD_HASH: 관리자 패널 별도 게이트 (앱 비번과 다르게 설정 권장)
+# ADMIN_PASSWORD_HASH='$2b$12$...'
 #
 # 주의: .env 파일은 절대 커밋하지 말 것 (.gitignore 포함 필수).
 

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -50,3 +50,6 @@ kiwipiepy==0.23.1
 scikit-learn==1.8.0
 redis==8.0.0
 
+# 인증 (비밀번호 bcrypt 해시)
+bcrypt==5.0.0
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,3 +58,6 @@ pytest-cov==7.1.0
 ruff==0.15.10
 redis==8.0.0
 
+# 인증 (비밀번호 bcrypt 해시)
+bcrypt==5.0.0
+

--- a/src/app.py
+++ b/src/app.py
@@ -34,6 +34,7 @@ from src.ui.dialogs.admin import show_admin_dialog
 from src.ui.dialogs.chunk_viewer import show_chunks_viewer_dialog
 from src.ui.session import init_session_state
 from src.ui.stream_responder import StreamResponder
+from src.utils.auth import verify_password
 from src.utils.logger import PerformanceLogger, setup_global_logging
 from src.utils.monitoring import get_system_stats
 from src.utils.paths import ensure_directories
@@ -130,12 +131,12 @@ ensure_directories()
 # --- 2. 세션 상태 초기화 (중앙 이관 호출) ---
 init_session_state()
 
-# 앱 전체 인증 게이트 — APP_PASSWORD 설정 시에만 활성 (미설정이면 게이트 없음) (#133)
-if settings.APP_PASSWORD and not st.session_state.get("app_authenticated"):
+# 앱 전체 인증 게이트 — APP_PASSWORD_HASH(bcrypt) 설정 시에만 활성 (미설정이면 게이트 없음) (#133)
+if settings.APP_PASSWORD_HASH and not st.session_state.get("app_authenticated"):
     st.title("RAG 챗봇 접속 인증")
     pw = st.text_input("접속 비밀번호", type="password", key="app_pw")
     if st.button("로그인"):
-        if pw == settings.APP_PASSWORD:
+        if verify_password(pw, settings.APP_PASSWORD_HASH):
             st.session_state.app_authenticated = True
             st.rerun()
         else:

--- a/src/app.py
+++ b/src/app.py
@@ -130,6 +130,18 @@ ensure_directories()
 # --- 2. 세션 상태 초기화 (중앙 이관 호출) ---
 init_session_state()
 
+# 앱 전체 인증 게이트 — APP_PASSWORD 설정 시에만 활성 (미설정이면 게이트 없음) (#133)
+if settings.APP_PASSWORD and not st.session_state.get("app_authenticated"):
+    st.title("RAG 챗봇 접속 인증")
+    pw = st.text_input("접속 비밀번호", type="password", key="app_pw")
+    if st.button("로그인"):
+        if pw == settings.APP_PASSWORD:
+            st.session_state.app_authenticated = True
+            st.rerun()
+        else:
+            st.error("비밀번호가 올바르지 않습니다.")
+    st.stop()
+
 # Redis 세션 복원 — REDIS_URL 설정 시 이전 대화 기록 복구
 # 로드밸런서로 다른 인스턴스로 라우팅되어도 대화 연속성 유지
 if settings.REDIS_URL:

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -140,6 +140,11 @@ class Settings(BaseSettings):
     SEMANTIC_CACHE_ENABLED: bool = Field(default=False)
     SEMANTIC_CACHE_COLLECTION_NAME: str = Field(default="semantic_cache")
     SEMANTIC_CACHE_THRESHOLD: float = Field(default=0.95)
+
+    # 8. 접근 인증 (#133) — 값 설정 시에만 게이트 활성, 미설정이면 게이트 없음
+    APP_PASSWORD: str | None = Field(default=None)
+    ADMIN_PASSWORD: str | None = Field(default=None)
+
     MAX_CHAT_HISTORY_TURNS: int = Field(default=5)
 
     # 8. Ollama 추론 제어

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -141,9 +141,9 @@ class Settings(BaseSettings):
     SEMANTIC_CACHE_COLLECTION_NAME: str = Field(default="semantic_cache")
     SEMANTIC_CACHE_THRESHOLD: float = Field(default=0.95)
 
-    # 8. 접근 인증 (#133) — 값 설정 시에만 게이트 활성, 미설정이면 게이트 없음
-    APP_PASSWORD: str | None = Field(default=None)
-    ADMIN_PASSWORD: str | None = Field(default=None)
+    # 8. 접근 인증 (#133) — bcrypt 해시 설정 시에만 게이트 활성, 미설정이면 게이트 없음
+    APP_PASSWORD_HASH: str | None = Field(default=None)
+    ADMIN_PASSWORD_HASH: str | None = Field(default=None)
 
     MAX_CHAT_HISTORY_TURNS: int = Field(default=5)
 

--- a/src/tests/unit/common/test_config_auth.py
+++ b/src/tests/unit/common/test_config_auth.py
@@ -2,12 +2,12 @@ from src.common.config import Settings
 
 
 class TestAuthGateConfig:
-    def test_auth_passwords_default_none(self):
-        """APP_PASSWORD/ADMIN_PASSWORD 기본값은 None이어야 한다.
+    def test_auth_password_hash_default_none(self):
+        """APP_PASSWORD_HASH/ADMIN_PASSWORD_HASH 기본값은 None이어야 한다.
 
-        opt-in 게이트 — 미설정이면 인증 없음. 기본값에 비밀번호가 박히면
-        (게이트 항상 ON 또는 하드코딩 비번) 보안 회귀이므로 가드한다.
+        opt-in 게이트 — 미설정이면 인증 없음. 기본값에 해시가 박히면
+        (게이트 항상 ON 또는 하드코딩 자격증명) 보안 회귀이므로 가드한다.
         """
         fields = Settings.model_fields
-        assert fields["APP_PASSWORD"].default is None
-        assert fields["ADMIN_PASSWORD"].default is None
+        assert fields["APP_PASSWORD_HASH"].default is None
+        assert fields["ADMIN_PASSWORD_HASH"].default is None

--- a/src/tests/unit/common/test_config_auth.py
+++ b/src/tests/unit/common/test_config_auth.py
@@ -1,0 +1,13 @@
+from src.common.config import Settings
+
+
+class TestAuthGateConfig:
+    def test_auth_passwords_default_none(self):
+        """APP_PASSWORD/ADMIN_PASSWORD 기본값은 None이어야 한다.
+
+        opt-in 게이트 — 미설정이면 인증 없음. 기본값에 비밀번호가 박히면
+        (게이트 항상 ON 또는 하드코딩 비번) 보안 회귀이므로 가드한다.
+        """
+        fields = Settings.model_fields
+        assert fields["APP_PASSWORD"].default is None
+        assert fields["ADMIN_PASSWORD"].default is None

--- a/src/tests/unit/utils/test_auth.py
+++ b/src/tests/unit/utils/test_auth.py
@@ -1,0 +1,25 @@
+import bcrypt
+
+from src.utils.auth import verify_password
+
+
+class TestVerifyPassword:
+    def test_correct_password(self):
+        hashed = bcrypt.hashpw(b"s3cret", bcrypt.gensalt()).decode("utf-8")
+        assert verify_password("s3cret", hashed) is True
+
+    def test_wrong_password(self):
+        hashed = bcrypt.hashpw(b"s3cret", bcrypt.gensalt()).decode("utf-8")
+        assert verify_password("nope", hashed) is False
+
+    def test_none_hash_denies(self):
+        """게이트 미설정(None)이면 어떤 입력도 거부(fail-closed)."""
+        assert verify_password("anything", None) is False
+
+    def test_empty_plain_denies(self):
+        hashed = bcrypt.hashpw(b"s3cret", bcrypt.gensalt()).decode("utf-8")
+        assert verify_password("", hashed) is False
+
+    def test_malformed_hash_denies(self):
+        """잘못된 해시 형식이어도 예외 없이 거부(fail-closed)."""
+        assert verify_password("s3cret", "not-a-bcrypt-hash") is False

--- a/src/ui/dialogs/admin.py
+++ b/src/ui/dialogs/admin.py
@@ -63,6 +63,18 @@ def _render_sync_progress(initialize_rag_system_callback):
 
 @st.dialog("데이터 관리 시스템", width="large", on_dismiss=reset_admin_active)
 def show_admin_dialog(db_manager, initialize_rag_system_callback):  # noqa: C901
+    # 관리자 인증 — ADMIN_PASSWORD 설정 시에만 요구 (미설정이면 인증 없음) (#133)
+    if settings.ADMIN_PASSWORD and not st.session_state.get("admin_authenticated"):
+        st.subheader("관리자 인증")
+        pw = st.text_input("관리자 비밀번호", type="password", key="admin_pw_input")
+        if st.button("확인", key="admin_pw_confirm"):
+            if pw == settings.ADMIN_PASSWORD:
+                st.session_state.admin_authenticated = True
+                st.rerun()
+            else:
+                st.error("비밀번호가 틀렸습니다.")
+        return
+
     # 백그라운드 동기화 실행 중이면 진행률 표시
     current_job = st.session_state.get("_current_sync_job")
     if current_job and current_job.running:

--- a/src/ui/dialogs/admin.py
+++ b/src/ui/dialogs/admin.py
@@ -8,6 +8,7 @@ from src.common.config import settings
 from src.common.constants import SupportedFormats
 from src.controllers.sync_controller import SyncController
 from src.pipeline import PipelineOrchestrator
+from src.utils.auth import verify_password
 from src.utils.health_check import repair_integrity, run_full_diagnostics
 from src.utils.paths import RAW_DATA_DIR
 from src.utils.unicode import normalize_to_nfc
@@ -63,12 +64,12 @@ def _render_sync_progress(initialize_rag_system_callback):
 
 @st.dialog("데이터 관리 시스템", width="large", on_dismiss=reset_admin_active)
 def show_admin_dialog(db_manager, initialize_rag_system_callback):  # noqa: C901
-    # 관리자 인증 — ADMIN_PASSWORD 설정 시에만 요구 (미설정이면 인증 없음) (#133)
-    if settings.ADMIN_PASSWORD and not st.session_state.get("admin_authenticated"):
+    # 관리자 인증 — ADMIN_PASSWORD_HASH(bcrypt) 설정 시에만 요구 (미설정이면 인증 없음) (#133)
+    if settings.ADMIN_PASSWORD_HASH and not st.session_state.get("admin_authenticated"):
         st.subheader("관리자 인증")
         pw = st.text_input("관리자 비밀번호", type="password", key="admin_pw_input")
         if st.button("확인", key="admin_pw_confirm"):
-            if pw == settings.ADMIN_PASSWORD:
+            if verify_password(pw, settings.ADMIN_PASSWORD_HASH):
                 st.session_state.admin_authenticated = True
                 st.rerun()
             else:

--- a/src/utils/auth.py
+++ b/src/utils/auth.py
@@ -1,0 +1,17 @@
+"""접근 인증 유틸 — 비밀번호는 평문이 아닌 bcrypt 해시로만 다룬다."""
+
+import bcrypt
+
+
+def verify_password(plain: str, hashed: str | None) -> bool:
+    """평문 비밀번호를 bcrypt 해시와 상수시간 비교한다.
+
+    - hashed가 비어 있으면(게이트 미설정) False.
+    - 해시 형식이 잘못된 경우에도 예외를 삼키고 False를 반환해(fail-closed) 접근을 거부한다.
+    """
+    if not plain or not hashed:
+        return False
+    try:
+        return bcrypt.checkpw(plain.encode("utf-8"), hashed.encode("utf-8"))
+    except (ValueError, TypeError):
+        return False


### PR DESCRIPTION
## 변경 사항 (Checklist)

* [x] 새로운 기능 추가 (feature)
* [ ] 버그 수정 (fix)
* [ ] 리팩토링 (refactor)
* [ ] 문서 수정 (docs)
* [x] 환경 설정 (setup)

## 주요 작업 내용

* **앱 전체 인증 게이트** (`src/app.py`): `APP_PASSWORD_HASH` 설정 시 앱 진입에 비밀번호를 요구. 미설정이면 게이트 비활성.
* **관리자 인증** (`src/ui/dialogs/admin.py`): `ADMIN_PASSWORD_HASH` 설정 시 데이터 관리 다이얼로그(지식베이스·DB 동기화) 진입에 관리자 비밀번호를 요구.
* **bcrypt 해시 검증** (`src/utils/auth.py`): `verify_password()` — 평문이 아닌 **bcrypt 해시(솔트 내장)** 와 **상수시간 비교**(`bcrypt.checkpw`). 해시가 없거나 형식이 잘못되면 fail-closed로 거부.
* **설정** (`src/common/config.py`): `APP_PASSWORD_HASH`, `ADMIN_PASSWORD_HASH` (기본값 `None` = opt-in).
* **의존성**: `bcrypt==5.0.0`을 dev/prod requirements에 명시.
* **문서** (`.env.example`): 해시 생성 one-liner + `$` 보간 방지(작은따옴표) 안내.
* **테스트**: `verify_password` 정상/오답/None/형식오류 + 설정 기본값 None 회귀 가드.

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**: #187에서 시연 편의로 Streamlit UI(8501)를 `0.0.0.0/0`으로 개방했는데, 앱 계층 인증이 없어 누구나 챗봇과 **관리자 패널(데이터 관리·DB 동기화)** 에 접근 가능한 노출이 존재.
* **원인 분석**: 방화벽 완화는 네트워크 계층 통제일 뿐, 앱 계층 접근 제어가 비어 있었음.
* **해결 방안 및 의사결정**: 앱(`APP_PASSWORD_HASH`)·관리자(`ADMIN_PASSWORD_HASH`) 2단 게이트. 비밀번호는 **평문이 아니라 bcrypt 해시로만** 저장하고 `bcrypt.checkpw`로 상수시간 검증해, 설정/로그에 평문이 남지 않도록 함. 두 값 모두 미설정 시 비활성(opt-in)이라 시연 마찰 0.
* **결과**: #187의 8501 개방과 본 PR의 앱 인증이 한 세트로 동작. 미설정이면 기존 동작 그대로(기존 `test_admin.py` 포함 전체 통과).

> 남은 한계(정직): 단일 공유 비밀번호 기반이며 레이트리밋·세션 만료·계정 분리는 없습니다. 사내 도구 위협 모델에는 충분하나, 다중 사용자/감사 추적이 필요해지면 별도 고도화 대상입니다.

## 테스트 결과 / 결과 증빙 (Screenshots / Logs)

* **전체 단위 테스트 307 passed** (신규 `test_auth.py`, `test_config_auth.py` 포함, 기존 `test_admin.py`도 변경 없이 통과):
```text
307 passed, 23 warnings in 41.15s
```
* **수동 검증**: `APP_PASSWORD_HASH` 설정 → 앱 진입 시 로그인 요구, 정답 해시 일치 시 진입 / 미설정 → 게이트 없음. 관리자도 동일.

## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요? (develop에서 분기)
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
* [x] 관련 이슈 번호를 연결했나요? (#133, epic7에서 분리)
* [x] 주간 발표 자료로 활용 가능한 직관적인 결과물(로그/검증 절차)을 첨부했나요?
* [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디

* 초기 구현은 평문 비교였는데, 리뷰 전 self-review에서 bcrypt 해시(솔트+상수시간 비교)로 전환했습니다. #187(8501 개방)을 받쳐주는 접근 제어라 함께 보시면 맥락이 명확합니다. opt-in이라 시연엔 영향 없습니다.
