### PR TITLE
fix(infra): 비루트 컨테이너 배포 결함 해결 — 로그 권한 + 문서 업로드 (#192)

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,17 +1,15 @@
-# WebSocket 타임아웃 방어 — Proxy/폐쇄망 환경 연결 끊김 방지
 [server]
+headless = true
 # 업로드 최대 크기 (MB)
 maxUploadSize = 200
-# WebSocket ping 주기 (초) — 유휴 연결 종료 방지
-# Proxy의 기본 타임아웃(60~120s)보다 짧게 설정
+# WebSocket 메시지 최대 크기 (MB) — maxUploadSize 이상으로 맞춰 대용량 업로드 시 1009(too big) 종료 방지
+maxMessageSize = 200
+# Docker Desktop/폐쇄망에서 업로드 핸드셰이크(requestFileURLs) 거부 방지.
+# 동일 출처(localhost) 전용 데모 구성에서 XSRF/CORS 차단이 file_uploader 세션 핸드셰이크를 막던 문제 해소.
 enableCORS = false
-enableXsrfProtection = true
-headless = true
+enableXsrfProtection = false
+# WebSocket 압축 비활성 — 프록시/Docker 포트포워딩 환경 호환성
+enableWebsocketCompression = false
 
 [browser]
-# 브라우저 재연결 시도 설정
-serverPort = 8501
-
-[runner]
-# 스크립트 실행 타임아웃 (초)
-fastReruns = true
+gatherUsageStats = false

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,9 @@ RUN mkdir -p data/raw data/processed vector_db logs && \
 COPY --chown=appuser:appgroup src/ /app/src/
 COPY --chown=appuser:appgroup prompts/ /app/prompts/
 COPY --chown=appuser:appgroup config/ /app/config/
+# Streamlit 설정(.streamlit/config.toml) 복사 — 미포함 시 컨테이너가 기본값으로만 동작하여
+# 업로드/WebSocket 방어 설정이 무효화됨(프로덕션 이미지에서도 적용되도록 보장)
+COPY --chown=appuser:appgroup .streamlit/ /app/.streamlit/
 
 # 포트 설정
 EXPOSE 8501

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ./models:/app/models
       - ./logs:/app/logs
       - ./.cache:/app/.cache
+      - ./.streamlit:/app/.streamlit
       - ./.env:/app/.env
     # .env 파일 로드
     env_file:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -72,6 +72,10 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command "Set-Location 'C:\path\to
     *   **용도**: 프라이빗 레포 환경에서의 자동 배포 및 컨테이너 정상 기동 확인.
     *   **실행**: `bash scripts/deploy.sh`
     *   **환경변수**: `DEPLOY_TIMEOUT`(기본 120초), `HEALTH_RETRIES`(20회), `HEALTH_INTERVAL`(6초), `COMPOSE_FILE`(docker-compose.yml)
+*   **`init-host-dirs.sh`**: 바인드 마운트 호스트 디렉토리(`logs`, `data/processed`, `vector_db`, `.cache` 등)를 미리 만들고 `1000:1000`으로 chown 하여 비루트 컨테이너(appuser, uid 1000)의 쓰기 권한을 보장합니다.
+    *   **용도**: `docker compose up` 시 Docker가 없는 바인드 소스를 root로 자동 생성하거나, 이전 root 실행의 잔여 파일이 남아 발생하는 `PermissionError`(예: `/app/logs/performance.jsonl`) 해소. `deploy.sh`·`ec2-startup.sh`의 `up` 직전에 자동 호출됩니다.
+    *   **실행**: `bash scripts/init-host-dirs.sh` (root 소유 디렉토리가 있으면 `sudo bash scripts/init-host-dirs.sh`)
+    *   **환경변수**: `APP_UID`(기본 1000), `APP_GID`(기본 1000) — Dockerfile의 appuser uid/gid와 일치시켜야 합니다.
 
 ## 🧹 관리 원칙
 1.  **일회성 스크립트**: 특정 이슈 해결을 위한 임시 디버깅 스크립트는 작업 완료 후 삭제를 원칙으로 합니다.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,14 +16,19 @@ timeout "$TIMEOUT_SECONDS" docker compose -f "$COMPOSE_FILE" build --no-cache ||
     exit 1
 }
 
-# 2. 컨테이너 기동
+# 2. 호스트 바인드 마운트 디렉토리 소유권 보장(비루트 컨테이너 쓰기 권한)
+# root 소유 디렉토리가 있으면 chown 에 sudo 가 필요할 수 있다(스크립트는 실패 시 경고만 남김).
+log "Ensuring host bind-mount dirs are writable..."
+bash scripts/init-host-dirs.sh
+
+# 3. 컨테이너 기동
 log "Starting containers..."
 timeout "$TIMEOUT_SECONDS" docker compose -f "$COMPOSE_FILE" up -d || {
     echo "ERROR: docker compose up timed out" >&2
     exit 1
 }
 
-# 3. 헬스체크 대기 (최대 HEALTH_RETRIES * HEALTH_INTERVAL 초)
+# 4. 헬스체크 대기 (최대 HEALTH_RETRIES * HEALTH_INTERVAL 초)
 log "Waiting for app health check..."
 for i in $(seq 1 "$HEALTH_RETRIES"); do
     STATUS=$(docker inspect --format='{{.State.Health.Status}}' rag-chatbot-app 2>/dev/null || echo "missing")

--- a/scripts/ec2-startup.sh
+++ b/scripts/ec2-startup.sh
@@ -41,6 +41,9 @@ docker image prune -af
 echo "Pulling the latest App image from ECR..."
 docker compose -f docker-compose.yml -f docker-compose.gpu.yml pull app
 
+echo "Ensuring host bind-mount dirs are writable by the non-root container..."
+sudo bash "$APP_DIR/scripts/init-host-dirs.sh"
+
 echo "Starting containers..."
 docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
 

--- a/scripts/init-host-dirs.sh
+++ b/scripts/init-host-dirs.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# 바인드 마운트 호스트 디렉토리를 비루트 컨테이너(appuser, uid 1000)가 쓸 수 있도록 보장한다.
+#
+# 배경: docker-compose 의 ./logs, ./data 등은 바인드 마운트라 이미지 빌드 시점의
+# chown(Dockerfile) 이 런타임에 무효화된다. 또한 호스트에 소스 디렉토리가 없으면
+# `docker compose up` 시 Docker 데몬(root)이 root:root 로 자동 생성해 버려,
+# uid 1000 으로 도는 컨테이너가 파일을 쓰지 못하고 PermissionError 가 발생한다.
+#
+# 이 스크립트는 쓰기 대상 디렉토리를 미리 만들고 APP_UID:APP_GID 로 chown 하여
+# 위 두 경우(없어서 root 자동생성 / 이전 root 실행의 잔여 파일)를 모두 해소한다.
+# 멱등하므로 `up` 전에 매번 호출해도 안전하다.
+set -euo pipefail
+
+# Dockerfile 의 appuser 와 동일(useradd -u 1000). 환경변수로 오버라이드 가능.
+APP_UID="${APP_UID:-1000}"
+APP_GID="${APP_GID:-1000}"
+
+# 스크립트 위치 기준 프로젝트 루트로 이동(어디서 호출해도 동작).
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# 컨테이너가 런타임에 쓰는 바인드 마운트 디렉토리 목록.
+WRITABLE_DIRS=(
+    logs
+    logs/trace
+    data/processed
+    data/backups
+    vector_db
+    .cache
+    models
+)
+
+echo "[init-host-dirs] Ensuring writable bind-mount dirs are owned by ${APP_UID}:${APP_GID}..."
+for dir in "${WRITABLE_DIRS[@]}"; do
+    mkdir -p "$dir"
+    if chown -R "${APP_UID}:${APP_GID}" "$dir" 2>/dev/null; then
+        echo "  ok: $dir"
+    else
+        # 비루트로 실행돼 chown 이 막히면 경고만 남기고 진행(이미 소유권이 맞는 경우가 대부분).
+        echo "  warn: chown 실패(권한 부족) — sudo 로 재실행하거나 소유권을 확인하세요: $dir" >&2
+    fi
+done
+echo "[init-host-dirs] Done."


### PR DESCRIPTION
## 변경 사항 (Checklist)

* [ ] 새로운 기능 추가 (feature)
* [x] 버그 수정 (fix)
* [ ] 리팩토링 (refactor)
* [ ] 문서 수정 (docs)
* [x] 환경 설정 (setup)

## 주요 작업 내용

비루트(appuser, uid 1000) 전환(#185) 이후 드러난 **두 가지 Docker 배포/런타임 결함**을 함께 해결합니다.

**1. 로그 권한 (PermissionError)**
- `scripts/init-host-dirs.sh` 추가: 쓰기 대상 바인드 디렉토리(`logs`, `logs/trace`, `data/processed`, `data/backups`, `vector_db`, `.cache`, `models`)를 생성하고 `1000:1000`으로 `chown -R`. 멱등.
- `deploy.sh`, `ec2-startup.sh`의 `docker compose up` 직전 호출 연결.
- `scripts/README.md` 문서화.

**2. 신규 문서 업로드 실패 (isSessionInfoSet: false)**
- `docker-compose.yml`에 `./.streamlit` 마운트, `Dockerfile`에 `.streamlit/` COPY 추가 — 그동안 config.toml이 컨테이너에 없어 Streamlit 기본값으로만 동작하던 것을 실제 로드되게 함.
- `.streamlit/config.toml`을 유효 설정으로 정리: `maxMessageSize` 명시, `enableCORS=false`, `enableXsrfProtection=false`, `enableWebsocketCompression=false`.

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**: (1) 앱이 기동 시 `/app/logs/performance.jsonl` PermissionError로 즉시 종료. (2) 신규 문서 업로드가 파일 선택 즉시 "Connection lost"와 함께 실패, Console에 `Cannot request file URLs (isServerConnected: true, isSessionInfoSet: false)`.
* **원인 분석**: (1) 바인드 마운트가 Dockerfile 빌드 시점 `chown`을 무효화 + 호스트 디렉토리가 root 소유. (2) `docker exec ... streamlit config show` 결과 모든 값이 주석(기본값) — `.streamlit/`이 이미지에 COPY/마운트되지 않아 의도한 업로드·WebSocket 설정이 전부 무효였음. 동일 출처 데모 구성에서 기본 XSRF/CORS 차단이 file_uploader 세션 핸드셰이크를 막아 업로드 불가.
* **해결 방안 및 의사결정**: 권한은 named volume(호스트 가시성 손실) 대신 `up` 전 소유권 보장 스크립트. 업로드는 config를 실제 로드시키고 XSRF/CORS/websocket 설정을 정합하게 조정. 두 결함 모두 #185 비루트 전환의 직접 후속이라 동일 브랜치로 묶음.
* **결과**: 컨테이너가 PermissionError 없이 기동하고, 브라우저에서 신규 문서 업로드 정상 동작 확인.

## 테스트 결과 / 결과 증빙 (Screenshots / Logs)

- 스크립트 3종 `bash -n` 문법 검증 통과.
- 컨테이너 재기동 후 `streamlit config show`에 설정값 반영 확인(주석 → 실제 값):
  ```
  enableCORS = false
  enableXsrfProtection = false
  maxUploadSize = 200
  maxMessageSize = 200
  enableWebsocketCompression = false
  ```
- `/_stcore/health` → `ok`, 브라우저에서 신규 문서 업로드 성공(이전 `isSessionInfoSet: false` 오류 미재현) — 로컬 Docker Desktop on Windows에서 실측.

## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요?
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
* [x] 관련 이슈 번호를 연결했나요? (Resolves #192)
* [x] 주간 발표 자료로 활용 가능한 직관적인 결과물(로그)을 첨부했나요?
* [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디

보안 주의: `enableXsrfProtection=false`는 CSRF 보호를 끄는 것으로, 8501이 외부에 노출된 환경(현 EC2 기본값, bad7e08)에서는 바람직하지 않습니다. 동일 출처 로컬 데모에선 안전하지만, 운영에선 **리버스 프록시 경유 + XSRF 재활성** 또는 **8501 접근 제한**이 필요합니다. 이 후속 강화는 #190(인증/시크릿)에서 함께 다루기를 제안합니다.

또한 로깅 실패가 앱 기동을 죽이는 견고성(graceful degrade) 개선은 이번 범위에서 제외했습니다.

Resolves #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)
