### PR TITLE
fix(ui): 출처 신뢰도 표시 공식이 필터 통과 청크를 저평가 — RERANKER_THRESHOLD 추종으로 재매핑 (#195)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -443,12 +443,22 @@ for msg_idx, msg in enumerate(st.session_state.messages):
                 source = metadata.get(MetadataFields.SRC_NAME, "알 수 없음")
                 page = metadata.get(MetadataFields.PG_NUM, "-")
 
-                # rerank_score 없을 때 RRF/기본값 0.0으로 무조건 경고 발생하는 오탐 방지
+                # 신뢰도 표시: 리랭커 점수를 합격선(RERANKER_THRESHOLD) 기준으로 재매핑한다.
+                # 합격선 통과 = 0.5, 만점 = 1.0 으로 선형 앵커링하여, 필터를 통과한 관련 청크가
+                # 부당하게 낮은 신뢰도(예: raw 0.535 -> 기존 공식 0.07)로 표시되던 문제를 해소한다.
+                # threshold 값을 바꿔도 표시가 자동 정합된다. (기존 (score-0.5)*2 는 피벗 0.5 를
+                # 하드코딩해 실제 RERANKER_THRESHOLD 와 어긋났음)
+                # rerank_score 부재(폴백/스킵) 시엔 오탐 방지를 위해 신뢰도 1.0·무경고를 유지한다.
                 score = metadata.get("rerank_score")
                 has_rerank_score = score is not None
                 score = score if has_rerank_score else doc.get("score", 0.0)
-                display_score = max(0.0, (score - 0.5) * 2) if has_rerank_score else 1.0
-                is_low_confidence = has_rerank_score and score < 0.5
+                threshold = settings.RERANKER_THRESHOLD
+                if has_rerank_score:
+                    span = max(1e-6, 1.0 - threshold)
+                    display_score = min(1.0, max(0.0, 0.5 + 0.5 * (score - threshold) / span))
+                else:
+                    display_score = 1.0
+                is_low_confidence = has_rerank_score and score < threshold
 
                 button_label = f"📄 {source} (p.{page}) - 신뢰도: {display_score:.2f}"
                 if is_low_confidence:


### PR DESCRIPTION
## 변경 사항 (Checklist)

* [ ] 새로운 기능 추가 (feature)
* [x] 버그 수정 (fix)
* [ ] 리팩토링 (refactor)
* [ ] 문서 수정 (docs)
* [ ] 환경 설정 (setup)

## 주요 작업 내용

- 출처 신뢰도 표시 공식을 `RERANKER_THRESHOLD` 추종 선형 앵커로 교체 (src/app.py)
  - `display = 0.5 + 0.5 * (score - T) / (1 - T)`, `T = settings.RERANKER_THRESHOLD`
- 저신뢰 경고 표식 발생 기준을 하드코딩 `0.5` -> `RERANKER_THRESHOLD`로 정합
- rerank_score 부재(폴백/스킵) 시 신뢰도 1.0·무경고 유지(기존 오탐 방지 동작 보존)

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**: "학부 구성" 질의에서 정답을 생성한 청크(리랭커 raw 0.535)가 출처 신뢰도 0.07로 표시됨. 답이 정확한데도 출처를 불신하게 되어 신뢰도 지표의 효용이 무너짐.
* **원인 분석**: 표시 공식 `max(0, (score-0.5)*2)`이 피벗 `0.5`를 하드코딩. 실제 관련성 필터 경계는 `RERANKER_THRESHOLD`(src/core/reranker.py + src/core/chains.py 2중 필터)인데 0.5와 어긋남. threshold가 0.5 -> 0.60으로 상향된 커밋(341e1c2) 때 표시 공식이 함께 갱신되지 않은 잔재. 트레이스 2,794개 실측(logs/trace/trace_2026-06-*.jsonl): 표시 신뢰도 중앙값 0.45, 99.8%가 0.6 미만으로 통과 청크가 일괄 저평가됨.
* **해결 방안 및 의사결정**: 표시 공식을 합격선 기준 선형 앵커(`0.5 + 0.5*(s-T)/(1-T)`)로 교체해 합격선 통과=0.5, 만점=1.0으로 매핑. threshold를 settings에서 참조하므로 값 조정 시 자동 정합. threshold를 0.25로 낮추는 밴드에이드(관련성 필터/정밀도를 깎음)는 표시 문제와 무관하므로 기각하고, threshold 값·리랭커 저평가는 별도 이슈로 분리.
* **결과**: "학부 구성" 정답 청크 0.07 -> 0.69(@T=0.25). 불변식 `s >= T => display >= 0.5` 성립으로 필터를 통과한 출처는 항상 0.5 이상 표시.

## 테스트 결과 / 결과 증빙 (Screenshots / Logs)

표시 신뢰도 매핑 (raw -> 기존 / 신규):

**T=0.25 (현재 운영값)**

| raw | 기존 | 신규 |
|---|---|---|
| 0.250 (합격선) | 0.00 | 0.50 |
| 0.535 (학부 구성) | 0.07 | 0.69 |
| 0.600 | 0.20 | 0.73 |
| 0.800 | 0.60 | 0.87 |
| 1.000 | 1.00 | 1.00 |

**T=0.60 (기본값)**

| raw | 기존 | 신규 |
|---|---|---|
| 0.600 (합격선) | 0.20 | 0.50 |
| 0.724 (실측 중앙) | 0.45 | 0.66 |
| 1.000 | 1.00 | 1.00 |

- 불변식 `s >= T => display >= 0.5` 성립 확인(스윕 검증).
- ruff check / ruff format 통과, py_compile OK.

## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요? (develop 최신 146ca5c 에서 분기)
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
* [x] 관련 이슈 번호를 연결했나요? (Resolves #195)
* [x] 주간 발표 자료로 활용 가능한 직관적인 결과물(스크린샷/로그)을 첨부했나요? (전/후 매핑 표)
* [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디

표시 공식만 고친 작은 PR입니다. threshold 값(0.60 vs 0.25)과 리랭커가 짧은 질의에 낮은 점수를 주는 저평가 문제는 표시와 독립이라 별도 이슈로 뺐습니다. 합격선 바닥을 0.5로 둔 것은 "필터를 통과한 출처는 최소 보통 신뢰"라는 의미 부여인데, 더 낮춰야 한다고 보시면 의견 주세요.

Generated with Claude Code (https://claude.com/claude-code)
