### PR TITLE
fix(ui): Redis 세션 식별을 쿠키 -> URL query param(sid)으로 전환 (#202)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -133,26 +133,21 @@ init_session_state()
 # Redis 세션 복원 — REDIS_URL 설정 시 이전 대화 기록 복구
 # 로드밸런서로 다른 인스턴스로 라우팅되어도 대화 연속성 유지
 if settings.REDIS_URL:
-    from src.utils.cookie import get_cookie_session_id, set_cookie_session_id
     from src.utils.redis_session import RedisSessionStore
 
-    # 1. 쿼리 스트링 또는 브라우저 쿠키에서 기존 세션 식별 시도
-    _session_id = st.query_params.get("sid", "") or get_cookie_session_id()
+    # 세션 식별을 URL query param(sid)으로 고정한다. 새로고침해도 URL이 유지되므로
+    # 동일 세션을 안정적으로 복원할 수 있다.
+    # (기존 쿠키 주입 방식은 set_cookie 직후 st.rerun() 레이스 + st.context.cookies
+    #  읽기 타이밍 의존으로 새로고침 복원이 불안정했음 → query param 으로 대체)
+    _session_id = st.query_params.get("sid", "")
 
-    # 2. 식별 불가능하고 아직 쿠키를 쓴 적이 없는 경우 새로 발급한 session_uuid 사용 및 브라우저 쿠키 동기화
     if not _session_id:
-        _session_id = st.session_state.get("session_uuid")
-        if not _session_id:  # 방어 가드
-            _session_id = str(uuid.uuid4())
-            st.session_state.session_uuid = _session_id
-
-        # 무한 루프 방지: 한 번만 쿠키 쓰기를 지시
-        if "st_session_id_written" not in st.session_state:
-            st.session_state.st_session_id_written = True
-            set_cookie_session_id(str(_session_id))
-            st.rerun()
+        # 신규 세션: session_uuid 를 발급/재사용하고 URL 에 고정한다(다음 런/새로고침부터 sid 로 식별).
+        _session_id = st.session_state.get("session_uuid") or str(uuid.uuid4())
+        st.session_state.session_uuid = _session_id
+        st.query_params["sid"] = _session_id
     else:
-        # 기존 세션 ID가 확인되었으므로, 현재 session_state 변수에도 덮어쓰기하여 일관성 유지
+        # 기존 세션 ID 확인 — session_state 에도 반영하여 일관성 유지
         st.session_state.session_uuid = str(_session_id)
 
     st.session_state._redis_session_id = str(_session_id)


### PR DESCRIPTION
## 변경 사항 (Checklist)

* [ ] 새로운 기능 추가 (feature)
* [x] 버그 수정 (fix)
* [ ] 리팩토링 (refactor)
* [ ] 문서 수정 (docs)
* [ ] 환경 설정 (setup)

## 주요 작업 내용

- Redis 세션 식별을 쿠키 -> URL query param(`sid`)으로 전환 (src/app.py)
- 쿠키 유틸(`get/set_cookie_session_id`) 의존 및 무한 rerun 방지 가드 제거
- 신규 세션은 `session_uuid` 발급/재사용 후 URL에 고정, 기존 세션은 `sid`로 식별

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**: 브라우저 새로고침 시 Redis에 저장된 이전 대화가 복원되지 않고 세션이 초기화됨.
* **원인 분석**: 기존 쿠키 기반 세션 식별이 `set_cookie` 직후 `st.rerun()` 레이스 + `st.context.cookies` 읽기 타이밍에 의존 → 새로고침 직후 쿠키를 안정적으로 읽지 못함. 무한 rerun을 막기 위한 가드(`st_session_id_written`)까지 필요한 복잡한 흐름이었음.
* **해결 방안 및 의사결정**: 세션 식별을 URL query param(`sid`)으로 고정. 새로고침해도 URL이 유지되므로 식별이 안정적이고 rerun 루프가 불필요해짐. #192(REDIS_URL 주입)로 세션 저장/복원은 활성화됐으나 식별 메커니즘의 불안정이 남아 있어, 이를 분리해 해결.
* **결과**: 쿠키/rerun 의존 제거로 흐름 단순화(코드 -5줄). 새로고침해도 동일 세션 복원.

## 테스트 결과 / 결과 증빙 (Screenshots / Logs)

- ruff check / ruff format 통과, py_compile OK.
- 변경 범위는 `if settings.REDIS_URL:` 블록(세션 식별 로직)에 한정. 쿠키 함수 코드 참조가 완전히 제거됨을 확인.
- 주의: 세션 복원 동작 자체(새로고침 후 대화 유지)는 Redis + 브라우저 환경에서의 수동 확인이 필요하다. 본 PR은 식별 메커니즘 전환의 코드 정합성(린트/컴파일/참조 제거)까지 검증했다.

## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요? (develop 최신에서 분기)
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
* [x] 관련 이슈 번호를 연결했나요? (Resolves #202)
* [ ] 주간 발표 자료로 활용 가능한 직관적인 결과물(스크린샷/로그)을 첨부했나요? (세션 복원은 런타임 확인이 필요 — 데모 시 캡처 예정)
* [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디

#192 작업 브랜치에 섞여 있던 세션 식별 변경을 분리해 올립니다. #192(비루트 배포)와는 별개 관심사라 독립 PR로 뺐습니다. 새로고침 세션 복원은 런타임(Redis + 브라우저) 확인이 필요한 변경이라, 로컬에서 한 번 검증해 주시면 좋습니다.

Generated with Claude Code (https://claude.com/claude-code)
