### PR TITLE
fix: HWP/HWPX 처리 결함 — 진단 유령 오탐·삭제 방지 + 출처를 섹션 위치로 표기 (#198)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -118,6 +118,29 @@ def get_doc_score(doc, default=0.0):
     return default
 
 
+# 페이지가 없는 포맷(HWP/HWPX/markdown): 페이지 번호 대신 섹션 위치로 출처를 표기한다.
+_PAGELESS_DOC_TYPES = {"hwp", "hwpx", "md", "markdown"}
+
+
+def get_source_location(metadata: dict) -> tuple[str, str] | None:
+    """출처 위치를 (종류, 값)으로 반환한다.
+
+    - PDF 등 페이지가 있는 포맷: ("page", "12")
+    - HWP/markdown 등 페이지가 없는 포맷: ("section", "제2장 학사운영")
+    - 위치 정보가 없으면 None.
+
+    markitdown 계열(HWP/markdown)은 페이지 경계가 없어 모든 청크가 pg_num=1 이므로,
+    의미 없는 "p.1" 대신 청크의 섹션 제목(헤더 경로)으로 위치를 표기한다.
+    """
+    doc_type = str(metadata.get(MetadataFields.DOC_TYPE, "")).lower()
+    if doc_type in _PAGELESS_DOC_TYPES:
+        section = str(metadata.get(MetadataFields.SEC_TITLE) or metadata.get(MetadataFields.HEADER_PATH) or "").strip()
+        if section and section not in ("기본 섹션", "UNKNOWN"):
+            return ("section", section)
+        return None
+    return ("page", str(metadata.get(MetadataFields.PG_NUM, "-")))
+
+
 # --- 1. 페이지 설정 ---
 st.set_page_config(
     page_title="기업 매뉴얼 챗봇 (관리 시스템 통합)",
@@ -172,13 +195,17 @@ def reset_doc_dialog():
 # [문서 원문 보기]
 @st.dialog("문서 원문 보기", on_dismiss=reset_doc_dialog)
 def show_document_dialog(doc: dict):
-    source = doc.get("metadata", {}).get(MetadataFields.SRC_NAME, "알 수 없음")
-    page = doc.get("metadata", {}).get(MetadataFields.PG_NUM, "-")
+    metadata = doc.get("metadata", {})
+    source = metadata.get(MetadataFields.SRC_NAME, "알 수 없음")
     score = doc.get("score", 0.0)
     content = doc.get("content", "")
 
     st.markdown(f"**출처:** {source}")
-    st.markdown(f"**페이지:** {page}")
+    loc = get_source_location(metadata)
+    if loc and loc[0] == "page":
+        st.markdown(f"**페이지:** p.{loc[1]}")
+    elif loc:
+        st.markdown(f"**위치:** {loc[1]}")
     st.markdown(f"**관련도 점수:** {score:.4f}")
     st.text_area("원문 내용", content, height=300)
     if st.button("닫기"):
@@ -441,7 +468,7 @@ for msg_idx, msg in enumerate(st.session_state.messages):
                     continue
                 metadata = doc.get("metadata", {})
                 source = metadata.get(MetadataFields.SRC_NAME, "알 수 없음")
-                page = metadata.get(MetadataFields.PG_NUM, "-")
+                loc = get_source_location(metadata)
 
                 # rerank_score 없을 때 RRF/기본값 0.0으로 무조건 경고 발생하는 오탐 방지
                 score = metadata.get("rerank_score")
@@ -450,7 +477,13 @@ for msg_idx, msg in enumerate(st.session_state.messages):
                 display_score = max(0.0, (score - 0.5) * 2) if has_rerank_score else 1.0
                 is_low_confidence = has_rerank_score and score < 0.5
 
-                button_label = f"📄 {source} (p.{page}) - 신뢰도: {display_score:.2f}"
+                if loc and loc[0] == "page":
+                    loc_text = f" (p.{loc[1]})"
+                elif loc:
+                    loc_text = f" · {loc[1]}"
+                else:
+                    loc_text = ""
+                button_label = f"📄 {source}{loc_text} - 신뢰도: {display_score:.2f}"
                 if is_low_confidence:
                     button_label += " ⚠️"
 

--- a/src/tests/unit/utils/test_health_check.py
+++ b/src/tests/unit/utils/test_health_check.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from src.utils.health_check import (
+    _get_local_files_info,
     check_data_integrity,
     check_database_status,
     check_env,
@@ -84,3 +85,23 @@ def test_run_full_diagnostics_all_pass(m1, m2, m3, m4):
 def test_run_full_diagnostics_fail(m1, m2, m3, m4):
     is_healthy, _ = run_full_diagnostics(silent=True)
     assert not is_healthy
+
+
+@patch("src.utils.health_check.generate_file_hash", return_value="hash123")
+def test_get_local_files_info_includes_hwp(mock_hash, tmp_path):
+    """회귀(#198): 로컬 파일 스캔이 .hwp/.hwpx 를 포함해야 한다.
+
+    스캔 확장자에서 HWP가 누락되면 정상 색인된 HWP 청크가 '로컬에 없음'으로 판정되어
+    유령 청크로 오탐되고, 자동 복구 단계에서 삭제되어 유효 데이터가 유실될 수 있다.
+    """
+    (tmp_path / "학칙.hwp").write_bytes(b"dummy")
+    (tmp_path / "안내.hwpx").write_bytes(b"dummy")
+    (tmp_path / "문서.pdf").write_bytes(b"dummy")
+
+    with patch("src.utils.health_check.RAW_DATA_DIR", tmp_path):
+        info = _get_local_files_info()
+
+    names = {v["name"] for v in info.values()}
+    assert "학칙.hwp" in names
+    assert "안내.hwpx" in names
+    assert "문서.pdf" in names

--- a/src/utils/health_check.py
+++ b/src/utils/health_check.py
@@ -11,7 +11,7 @@ except ImportError:
     # 직접 실행 시 src를 찾지 못할 경우를 대비한 로컬 임포트 (paths.py가 같은 폴더에 있으므로 가능)
     from paths import BASE_DIR, RAW_DATA_DIR, REQUIRED_DIRECTORIES, ensure_directories
 from src.common.config import settings
-from src.common.constants import MetadataFields
+from src.common.constants import MetadataFields, SupportedFormats
 from src.utils.file_utils import generate_file_hash
 
 # 로깅 설정
@@ -65,7 +65,7 @@ def check_data_integrity():
             logger.error(f"  [MISSING] {path.name} 경로 누락: {path}")
 
     raw_files = []
-    for ext in [".pdf", ".md", ".markdown"]:
+    for ext in SupportedFormats.EXTENSIONS:
         raw_files.extend(list(RAW_DATA_DIR.glob(f"**/*{ext}")))
 
     if raw_files:
@@ -130,7 +130,7 @@ def check_database_status():
 def _get_local_files_info() -> dict[str, dict]:
     """로컬 raw 데이터 파일들의 정보(상대 경로, 해시)를 추출"""
     raw_files = []
-    for ext in [".pdf", ".md", ".markdown"]:
+    for ext in SupportedFormats.EXTENSIONS:
         raw_files.extend(list(RAW_DATA_DIR.glob(f"**/*{ext}")))
 
     local_files_info = {}


### PR DESCRIPTION
## 변경 사항 (Checklist)

* [ ] 새로운 기능 추가 (feature)
* [x] 버그 수정 (fix)
* [ ] 리팩토링 (refactor)
* [ ] 문서 수정 (docs)
* [ ] 환경 설정 (setup)

## 주요 작업 내용

- [유령/심각] 진단 로컬 파일 스캔 확장자를 `SupportedFormats.EXTENSIONS`(SSoT)로 통일 → HWP/HWPX 누락 해소 (src/utils/health_check.py)
- [페이지] HWP/markdown 출처를 의미 없는 "p.1" 대신 섹션 위치로 표기 (src/app.py)
- 회귀 테스트 추가: 로컬 스캔이 `.hwp/.hwpx`를 포함하는지 검증

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**: (1) 진단이 정상 HWP 청크를 유령으로 오탐 → 자동 복구가 삭제하여 데이터 유실 가능. (2) HWP 출처가 전부 "p.1"로 표시돼 위치 식별 불가.
* **원인 분석**: (1) `_get_local_files_info` 등이 스캔 확장자를 `[".pdf", ".md", ".markdown"]`로 하드코딩해 `.hwp/.hwpx`를 누락 → DB의 HWP 청크가 로컬 매칭 실패 → `ghost_chunks` 분류 → `_repair_ghost_chunks`가 삭제. (2) markitdown(HWP/markdown)은 페이지 경계가 없어 모든 청크가 `pg_num=1`.
* **해결 방안 및 의사결정**: (1) 확장자를 `SupportedFormats.EXTENSIONS`로 SSoT화 — 신규 포맷 추가 시 진단도 자동 반영. (2) `get_source_location()` 헬퍼로 페이지 없는 포맷(hwp/hwpx/md/markdown)은 섹션 제목, PDF 등은 기존 페이지를 유지(회귀 방지 allowlist). 섹션 위치는 청크가 이미 보유한 `sec_title`/`header_path` 메타를 재사용(신규 추출 불요). 섹션 정보가 없으면 위치 표기 생략.
* **결과**: HWP 청크 유령 오탐·삭제 제거. HWP 출처가 섹션 위치로 표시되고 PDF는 페이지 그대로 유지.

## 테스트 결과 / 결과 증빙 (Screenshots / Logs)

출처 표기 전/후:

| 포맷 | 변경 전 | 변경 후 |
|---|---|---|
| HWP | `조선대학교_학칙.hwp (p.1)` | `조선대학교_학칙.hwp · 제2장 학사운영` |
| PDF (유지) | `문서.pdf (p.12)` | `문서.pdf (p.12)` |

- ruff check / ruff format 통과, py_compile OK.
- `test_health_check` 10개 통과(신규 회귀 테스트 1 포함), app import 스모크(`test_app_eager_load`) 통과.

## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요? (develop 최신에서 분기)
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
* [x] 관련 이슈 번호를 연결했나요? (Resolves #198)
* [x] 주간 발표 자료로 활용 가능한 직관적인 결과물(스크린샷/로그)을 첨부했나요? (전/후 표기 비교 표)
* [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디

유령 오탐은 자동 복구가 정상 HWP 청크를 삭제할 수 있던 데이터 유실 버그라 우선 처리했습니다. 페이지 표기는 PDF 회귀를 막기 위해 "페이지 없는 포맷"만 allowlist로 분기했고, 섹션 위치는 기존 메타데이터를 재사용했습니다. HWP 마크다운에 헤더(섹션)가 잘 잡히는지는 실데이터에서 한 번 확인해 주시면 좋겠습니다(헤더 없으면 위치 생략).

Generated with Claude Code (https://claude.com/claude-code)
