### PR TITLE
fix(ui): 전문가 모드 추론 타이머 멈춤 오인 해소 (#200)

### DIFF
--- a/src/tests/unit/ui/test_stream_responder.py
+++ b/src/tests/unit/ui/test_stream_responder.py
@@ -51,6 +51,30 @@ class TestStreamResponder:
         responder.process_step({"stage": "retrieval", "status": "complete"})
         assert "end" in responder.stage_latencies["retrieval"]
 
+    def test_display_latencies_in_flight_generation(self, mock_st):
+        """진행 중 단계(LLM 준비/생성)는 '생성 중'으로 표기되어 멈춤 오인을 막는다. (#200)"""
+        responder = StreamResponder(MagicMock(), MagicMock())
+        responder.process_step({"stage": "retrieval", "status": "running"})
+        responder.process_step({"stage": "retrieval", "status": "complete"})
+        # 생성 단계 시작(첫 토큰 전) — 끝나지 않은 in-flight 상태
+        responder.process_step({"stage": "generation", "status": "running"})
+
+        rendered = responder.latency_placeholder.info.call_args[0][0]
+        assert "응답 생성 중" in rendered  # 헤더 진행 표시
+        assert "generation: (생성 중...)" in rendered  # 진행 중 단계 라인
+        assert "retrieval:" in rendered  # 완료 단계는 소요시간 유지
+
+    def test_display_latencies_all_complete_no_busy_marker(self, mock_st):
+        """모든 단계 완료 시 진행 표시 없이 소요시간만 노출한다. (회귀 가드)"""
+        responder = StreamResponder(MagicMock(), MagicMock())
+        responder.process_step({"stage": "retrieval", "status": "running"})
+        responder.process_step({"stage": "retrieval", "status": "complete"})
+
+        rendered = responder.latency_placeholder.info.call_args[0][0]
+        assert "생성 중" not in rendered
+        assert "처리 중" not in rendered
+        assert "총 소요시간" in rendered
+
     def test_format_docs(self, mock_st):
         responder = StreamResponder(MagicMock(), MagicMock())
 

--- a/src/ui/stream_responder.py
+++ b/src/ui/stream_responder.py
@@ -76,17 +76,27 @@ class StreamResponder:
         over_limit = total_latency > 5.0
 
         if st.session_state.show_expert_mode:
+            stage_durations = self._stage_durations
+            # 시작했으나 아직 끝나지 않은 단계(검색/리랭킹/LLM 준비·생성). 이 구간엔 스텝
+            # 이벤트가 없어 경과시간이 멈춰 보이므로, 진행 중임을 명시해 오인을 막는다. (#200)
+            in_flight = [s for s, v in self.stage_latencies.items() if "end" not in v]
+
             header = f"**총 소요시간: {total_latency:.2f}초**"
-            if over_limit:
+            if in_flight:
+                busy = "응답 생성 중" if "generation" in in_flight else "처리 중"
+                header = f"{header} · ⏳ {busy}..."
+            elif over_limit:
                 header = f"⚠️ {header} (5초 초과)"
 
-            stage_durations = self._stage_durations
             bottleneck = max(stage_durations, key=lambda s: stage_durations[s]) if stage_durations else None
 
             lines = [header]
             for stage, elapsed in stage_durations.items():
                 marker = " ← 병목" if over_limit and stage == bottleneck else ""
                 lines.append(f"- {stage}: {elapsed:.2f}초{marker}")
+            for stage in in_flight:
+                label = "생성 중" if stage == "generation" else "처리 중"
+                lines.append(f"- {stage}: ({label}...)")
 
             self.latency_placeholder.info("\n".join(lines))
         else:
@@ -158,15 +168,14 @@ class StreamResponder:
 
     def consume_stream(self):
         """스트리밍 생성 제네레이터를 읽어서 UI를 실시간 업데이트하고 결과를 로깅합니다."""
-        show_expert_mode = st.session_state.show_expert_mode
         if not st.session_state.stream_iter:
             return
 
         try:
-            spinner_ctx = (
-                st.spinner("답변을 생성하고 있습니다...") if not show_expert_mode else contextlib.nullcontext()
-            )
-            with spinner_ctx:
+            # 전문가 모드에서도 스피너를 표시한다. LLM 준비·검색·리랭킹처럼 스텝 이벤트가 없는
+            # 블로킹 구간에는 서버가 경과시간을 다시 그리지 못하지만, 스피너 애니메이션은
+            # 브라우저에서 계속 돌아 처리가 멈춘 것처럼 보이는 오인을 막는다. (#200)
+            with st.spinner("답변을 생성하고 있습니다..."):
                 for step in st.session_state.stream_iter:
                     if st.session_state.stop_generation:
                         break


### PR DESCRIPTION
## 변경 사항 (Checklist)

* [ ] 새로운 기능 추가 (feature)
* [x] 버그 수정 (fix)
* [ ] 리팩토링 (refactor)
* [ ] 문서 수정 (docs)
* [ ] 환경 설정 (setup)

## 주요 작업 내용

전문가(상세) 모드에서 답변 생성 중 "총 소요시간" 타이머가 LLM 준비 구간 등에서 멈춘 것처럼 보여, 사용자가 처리 중단으로 오인하던 문제를 해결합니다.

- `src/ui/stream_responder.py` `consume_stream`: 전문가 모드에서도 `st.spinner`를 표시. 기존에는 전문가 모드일 때 스피너를 끄고(`contextlib.nullcontext`) 지연시간 패널만 보여줬는데, 스텝 이벤트가 없는 블로킹 구간에는 패널이 갱신되지 않아 멈춰 보였습니다. 스피너 애니메이션은 브라우저(클라이언트) 측에서 돌므로 서버가 블로킹 중이어도 계속 회전해 "동작 중"이 분명해집니다.
- `display_latencies`: 시작했으나 아직 끝나지 않은 단계(in-flight)를 표기. 헤더에 `· ⏳ 응답 생성 중...`(generation) 또는 `처리 중...`(검색/리랭킹), 단계 라인에 `(생성 중...)`/`(처리 중...)`를 추가했습니다.
- 동기 소비 루프와 중단(`stop_generation`→`iter.close()`) 로직은 변경하지 않아 회귀 표면을 최소화했습니다.

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**: 전문가 모드에서 답변 생성 시 "총 소요시간" 숫자가 LLM 준비/첫 토큰 지연 구간에 멈춰 보여 처리가 중단된 것으로 오인.
* **원인 분석**: `display_latencies`는 `process_step`에서만 호출되고(`stream_responder.py:50`), `process_step`은 스트림 제너레이터가 스텝을 yield할 때만 실행됩니다(`stream_responder.py:170` `for step in stream_iter`). `chains.py:366 stream()`의 블로킹 구간(retrieval/reranking/generation 첫 토큰)에는 스텝 이벤트가 없어 패널이 다시 그려지지 않습니다. Streamlit은 스크립트가 단일 스레드라, for-루프가 `next()`에서 막히는 동안 서버는 어떤 위젯도 다시 그릴 수 없습니다.
* **해결 방안 및 의사결정**: 실제로 똑딱이는 숫자는 백그라운드 워커 스레드가 필요한데, 기존 중단(close) 취소 의미·스레드 수명과 얽혀 회귀 위험이 큽니다. 대신 (1) 클라이언트 측에서 도는 `st.spinner`를 전문가 모드에도 적용해 블로킹 구간에 "동작 중" 애니메이션을 보장하고, (2) in-flight 단계를 패널에 명시해 어느 단계가 진행 중인지 드러냈습니다. 동기 루프를 그대로 둬 회귀 표면을 최소화했습니다.
* **결과**: 블로킹 구간에도 스피너가 돌고 패널이 "응답 생성 중..."을 표시해 멈춤 오인이 사라집니다. 단계 경계마다 숫자는 정확히 갱신되며, 최종 총 소요시간 측정 로직(`_stage_durations`, `finalize_stream`)은 불변이라 수치 정확성을 유지합니다.

## 테스트 결과 / 결과 증빙 (Screenshots / Logs)

- `src/tests/unit/ui/test_stream_responder.py` 10개 통과(신규 2개: in-flight '생성 중' 표기 검증, 전체 완료 시 진행 표시 미노출 회귀 가드).
- `ruff check` / `ruff format --check` 통과.

전/후 (전문가 패널, generation 첫 토큰 대기 구간):

```
[전]  총 소요시간: 2.13초          (스피너 없음, generation 라인 없음 → 숫자 정지로 보임)

[후]  총 소요시간: 2.13초 · ⏳ 응답 생성 중...
      - retrieval: 0.41초
      - reranking: 1.72초
      - generation: (생성 중...)      + 스피너 회전
```

(라이브 화면의 스피너 애니메이션은 런타임 확인 권장)

## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요?
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
* [x] 관련 이슈 번호를 연결했나요? (Resolves #200)
* [x] 주간 발표 자료로 활용 가능한 직관적인 결과물(스크린샷/로그)을 첨부했나요?
* [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디

실제로 똑딱이는 숫자(라이브 타이머)는 백그라운드 워커 스레드가 필요하지만, 기존 중단(`stop_generation`→`iter.close()`) 취소 의미·스레드 수명 관리와 얽혀 회귀 위험이 커 이번엔 회귀 최소 방식(활동 표시)을 택했습니다. 진짜 라이브 타이머가 필요하면 별도 이슈로 분리 제안합니다. UI 문자열의 `⏳`/`⚠️`는 기존 패널의 `⚠️ 5초 초과`·`← 병목` 표기 스타일과 정합한 것입니다.

Resolves #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
