### PR TITLE
fix(sync): 데이터 동기화 에러 가시성 — 로그 보존 + UI 결과 패널 유지 (#201)

### DIFF
--- a/src/controllers/sync_controller.py
+++ b/src/controllers/sync_controller.py
@@ -120,6 +120,12 @@ class SyncController:
             except SyncCancelledError:
                 j.mark_cancelled()
             except Exception as e:
+                # 백그라운드 스레드 예외는 job 상태에만 담기던 것을 로그에도 남긴다.
+                # foreground/main.py와 동일하게 스택트레이스를 보존한다. (#201)
+                logger.error(
+                    f"백그라운드 동기화 실패 (parser={parser_type}, 최근 파일={j.file_name!r}): {e}",
+                    exc_info=True,
+                )
                 j.fail(str(e))
 
         thread = threading.Thread(target=run, args=(job,), daemon=True, name="sync-background")

--- a/src/tests/unit/controllers/test_sync_controller.py
+++ b/src/tests/unit/controllers/test_sync_controller.py
@@ -120,6 +120,33 @@ class TestSyncController:
             mock_orchestrator.return_value.run_ingestion.assert_called_once()
             assert args[0].completed is True
 
+    @patch("src.controllers.sync_controller.logger")
+    @patch("src.controllers.sync_controller.threading.Thread")
+    @patch("src.controllers.sync_controller.PipelineOrchestrator")
+    @patch("src.controllers.sync_controller.st")
+    def test_background_failure_logs_stacktrace(self, mock_st, mock_orchestrator, mock_thread, mock_logger):
+        """백그라운드 동기화 실패 시 logger.error(exc_info=True)로 스택트레이스를 남기고 job에 기록한다. (#201)"""
+        mock_st.session_state = MagicMock()
+        mock_st.session_state.get.return_value = None
+        mock_orchestrator.return_value.run_ingestion.side_effect = RuntimeError("ingestion boom")
+
+        job = SyncController.trigger_sync_background("docling", force=True)
+        run_func = mock_thread.call_args[1]["target"]
+        args = mock_thread.call_args[1]["args"]
+
+        with (
+            patch("src.utils.health_check.run_full_diagnostics") as mock_diag,
+            patch("src.utils.health_check.repair_integrity"),
+        ):
+            mock_diag.return_value = (True, {})
+            run_func(*args)
+
+        mock_logger.error.assert_called_once()
+        assert mock_logger.error.call_args[1]["exc_info"] is True
+        assert job.error == "ingestion boom"
+        assert job.running is False
+        assert job.completed is False
+
     @patch("src.controllers.sync_controller.PipelineOrchestrator")
     @patch("src.controllers.sync_controller.st")
     def test_trigger_sync(self, mock_st, mock_orchestrator):

--- a/src/tests/unit/ui/dialogs/test_admin.py
+++ b/src/tests/unit/ui/dialogs/test_admin.py
@@ -2,7 +2,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.ui.dialogs.admin import API_URL, _render_sync_progress, reset_admin_active, show_admin_dialog
+from src.ui.dialogs.admin import (
+    API_URL,
+    _render_sync_progress,
+    _render_sync_result,
+    reset_admin_active,
+    show_admin_dialog,
+)
 
 
 @pytest.fixture
@@ -102,7 +108,7 @@ class TestAdminDialog:
                 mock_requests.post.assert_any_call(f"{API_URL}/api/admin/backups")
                 mock_requests.post.assert_any_call(f"{API_URL}/api/admin/backups/restore?filename=backup1.tar.gz")
 
-    def test_render_sync_progress(self, mock_st):
+    def test_render_sync_progress_running_cancel(self, mock_st):
         job = MagicMock()
         job.snapshot.return_value = {
             "running": True,
@@ -117,12 +123,91 @@ class TestAdminDialog:
         mock_st.session_state.get.return_value = job
         mock_st.button.return_value = True
 
-        with patch("src.ui.dialogs.admin.time.sleep"):
-            _render_sync_progress(MagicMock())
-            job.request_cancel.assert_called_once()
+        _render_sync_progress()
+        job.request_cancel.assert_called_once()
 
-            job.snapshot.return_value["running"] = False
-            job.snapshot.return_value["completed"] = True
-            cb = MagicMock()
-            _render_sync_progress(cb)
-            cb.assert_called_once()
+    def test_render_sync_progress_terminal_handoff(self, mock_st):
+        """가동 종료 시 결과 패널로 1회 핸드오프(st.rerun)하고 자동으로 닫지 않는다. (#201)"""
+        job = MagicMock()
+        job.snapshot.return_value = {
+            "running": False,
+            "total": 10,
+            "current": 10,
+            "file_name": "test.pdf",
+            "percent": 100,
+            "completed": True,
+            "cancelled": False,
+            "error": None,
+        }
+        mock_st.session_state.get.return_value = job
+
+        _render_sync_progress()
+
+        mock_st.rerun.assert_called_once()
+        # 자동 닫기(admin_active=False)·job 소거를 하지 않아 결과가 부모로 인계된다.
+        assert mock_st.session_state.admin_active is True
+
+    def test_render_sync_result_completed(self, mock_st):
+        """완료 결과는 성공 메시지 + RAG 재초기화 1회. 확인 전까지 패널 유지. (#201)"""
+        job = MagicMock()
+        job.snapshot.return_value = {
+            "running": False,
+            "completed": True,
+            "cancelled": False,
+            "error": None,
+            "file_name": "",
+            "current": 1,
+            "total": 1,
+            "percent": 100,
+        }
+        cb = MagicMock()
+        mock_st.button.return_value = False  # 확인 미클릭 → 유지
+
+        _render_sync_result(job, cb)
+
+        cb.assert_called_once()
+        mock_st.success.assert_called_once()
+        mock_st.rerun.assert_not_called()
+
+    def test_render_sync_result_error_keeps_panel(self, mock_st):
+        """오류 결과는 사유 + 마지막 처리 파일을 표시하고, 재초기화하지 않는다. (#201)"""
+        job = MagicMock()
+        job.snapshot.return_value = {
+            "running": False,
+            "completed": False,
+            "cancelled": False,
+            "error": "ingestion boom",
+            "file_name": "broken.hwp",
+            "current": 0,
+            "total": 3,
+            "percent": 0,
+        }
+        cb = MagicMock()
+        mock_st.button.return_value = False
+
+        _render_sync_result(job, cb)
+
+        mock_st.error.assert_called_once()
+        assert "ingestion boom" in mock_st.error.call_args[0][0]
+        mock_st.caption.assert_called_once()
+        cb.assert_not_called()
+
+    def test_render_sync_result_ack_closes(self, mock_st):
+        """'확인' 클릭 시 job을 비우고 rerun으로 결과 패널을 닫는다. (#201)"""
+        job = MagicMock()
+        job.snapshot.return_value = {
+            "running": False,
+            "completed": True,
+            "cancelled": False,
+            "error": None,
+            "file_name": "",
+            "current": 1,
+            "total": 1,
+            "percent": 100,
+        }
+        mock_st.button.return_value = True  # 확인 클릭
+
+        _render_sync_result(job, MagicMock())
+
+        assert mock_st.session_state._current_sync_job is None
+        mock_st.rerun.assert_called_once()

--- a/src/ui/dialogs/admin.py
+++ b/src/ui/dialogs/admin.py
@@ -22,8 +22,8 @@ def reset_admin_active():
     st.session_state.admin_active = False
 
 
-def _render_sync_progress(initialize_rag_system_callback):
-    """백그라운드 동기화 진행률 폴링 프래그먼트."""
+def _render_sync_progress():
+    """백그라운드 동기화 진행률 폴링 프래그먼트(가동 중에만 마운트)."""
 
     @st.fragment(run_every="1s")
     def _progress_fragment():
@@ -46,32 +46,45 @@ def _render_sync_progress(initialize_rag_system_callback):
                 job.request_cancel()
             return
 
-        # 완료 / 취소 / 오류
-        st.session_state._current_sync_job = None
-        if snap["completed"]:
-            if initialize_rag_system_callback:
-                initialize_rag_system_callback()
-            st.success("동기화가 완료되었습니다.")  # pragma: no cover
-        elif snap["cancelled"]:
-            st.warning("동기화가 취소되었습니다.")  # pragma: no cover
-        elif snap["error"]:
-            st.error(f"동기화 오류: {snap['error']}")  # pragma: no cover
-
-        time.sleep(0.5)
-        st.session_state.admin_active = False
-        st.rerun()  # pragma: no cover
+        # 가동 종료(완료/취소/오류) → 결과 패널로 1회 핸드오프한다. 자동으로 닫지 않고
+        # job을 유지해, 부모 다이얼로그가 결과/에러를 운영자 확인까지 보여주도록 한다. (#201)
+        st.rerun()
 
     _progress_fragment()
 
 
+def _render_sync_result(job, initialize_rag_system_callback):
+    """동기화 종료 결과 패널. 자동으로 닫지 않고 운영자가 '확인'할 때까지 유지한다. (#201)"""
+    snap = job.snapshot()
+    st.subheader("동기화 결과")
+
+    if snap["completed"]:
+        if initialize_rag_system_callback:
+            initialize_rag_system_callback()
+        st.success("동기화가 완료되었습니다.")
+    elif snap["cancelled"]:
+        st.warning("동기화가 취소되었습니다.")
+    elif snap["error"]:
+        st.error(f"동기화 오류: {snap['error']}")
+        if snap["file_name"]:
+            st.caption(f"마지막 처리 파일: {snap['file_name']}")
+
+    if st.button("확인", key="sync_result_ack_btn"):
+        st.session_state._current_sync_job = None
+        st.rerun()
+
+
 @st.dialog("데이터 관리 시스템", width="large", on_dismiss=reset_admin_active)
 def show_admin_dialog(db_manager, initialize_rag_system_callback):  # noqa: C901
-    # 백그라운 동기화 실행 중이면 진행률 표시
+    # 백그라운드 동기화가 가동 중이면 진행률을, 종료되었으면 결과 패널을 표시한다.
     current_job = st.session_state.get("_current_sync_job")
     if current_job and current_job.running:
         st.subheader("동기화 진행 중...")  # pragma: no cover
         st.info("파일을 처리하는 동안 다른 작업이 가능합니다.")  # pragma: no cover
-        _render_sync_progress(initialize_rag_system_callback)
+        _render_sync_progress()
+        return
+    if current_job:
+        _render_sync_result(current_job, initialize_rag_system_callback)
         return
 
     tab1, tab2 = st.tabs(["문서 및 동기화 관리", "백업 및 복원"])


### PR DESCRIPTION
## 변경 사항 (Checklist)

* [ ] 새로운 기능 추가 (feature)
* [x] 버그 수정 (fix)
* [ ] 리팩토링 (refactor)
* [ ] 문서 수정 (docs)
* [ ] 환경 설정 (setup)

## 주요 작업 내용

관리자 데이터 동기화(파이프라인 가동) 중/후 발생한 에러를 운영자가 확인할 수 없던 문제를 해결합니다. (1) 백그라운드 실패가 로그에 남지 않고(스택트레이스 유실), (2) 완료/오류 후 상태 패널이 0.5초 만에 자동으로 닫혀 결과·에러를 검토할 수 없었습니다.

**1. 백그라운드 실패 로그 미기록 → 스택트레이스 보존**
- `src/controllers/sync_controller.py` 백그라운드 스레드 `run`의 `except Exception` 블록이 `j.fail(str(e))`로 job 상태에만 담고 로거를 호출하지 않아 스택트레이스가 유실됐습니다. `logger.error(..., exc_info=True)`를 추가했습니다(파서·최근 처리 파일 컨텍스트 포함). foreground 경로 및 `main.py`와 동일한 로깅 정책으로 정합화.

**2·3. UI 에러 확인 불가 + 패널 자동 닫힘 → 결과 패널 유지**
- 운영 UI의 활성 경로는 `src/ui/dialogs/admin.py`의 `_render_sync_progress`(백그라운드 + `@st.fragment(run_every="1s")` 폴링)입니다. 기존에는 가동 종료 시 `st.error(...)`로 에러를 잠깐 띄운 뒤 곧바로 `time.sleep(0.5) → admin_active=False → st.rerun()`으로 다이얼로그를 자동으로 닫아, 에러/결과가 0.5초 만에 사라졌습니다.
- 폴링 프래그먼트는 가동 중에만 진행률을 그리고, 종료되면 `st.rerun()`으로 **결과 패널에 1회 핸드오프**하도록 변경했습니다. 새 `_render_sync_result`가 완료/취소/오류를 **'확인' 버튼을 누를 때까지 유지**하고, 오류 시 사유와 **마지막 처리 파일**을 표시합니다. RAG 재초기화 콜백은 완료 시 1회만 실행합니다.

> 참고: 이슈 본문은 패널 접힘 원인을 `sync_controller.py:165`(foreground `trigger_sync`의 `expanded=False`)로 추정했으나, 실제 운영 UI는 `trigger_sync_background` + admin 폴링 프래그먼트 경로를 사용합니다(foreground `trigger_sync`는 현재 production 호출부가 없어 테스트만 사용). 그래서 실제 자동 닫힘 지점인 admin 프래그먼트를 수정했습니다.

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**: 동기화 중 에러가 (1) 로그에 남지 않고(스택트레이스 유실), (2) UI에서도 0.5초 자동 닫힘으로 확인 불가, (3) 완료 결과도 자동으로 닫혀 검토 불가.
* **원인 분석**: (1) 백그라운드 `except`가 `j.fail`만 호출(로거 없음). (2)(3) admin 폴링 프래그먼트가 종료 직후 `sleep → admin_active=False → rerun`으로 다이얼로그를 강제 종료. 활성 경로가 background인데 이슈 추정은 foreground(`:165`)였음을 코드 추적으로 규명(`trigger_sync`는 production 미사용).
* **해결 방안 및 의사결정**: 로깅은 foreground/`main.py`와 동일하게 `exc_info=True`. UI는 자동 닫기를 제거하고 진행률 프래그먼트와 결과 패널을 분리해, 종료 시 부모 다이얼로그로 1회 핸드오프 → 결과/에러를 '확인'까지 유지. 라이브 갱신은 가동 중에만 필요하므로 종료 후 폴링을 멈추는 구조가 자연스럽고, 매초 결과 재렌더(깜빡임)도 피합니다.
* **결과**: 백그라운드 실패가 `app.log`에 스택트레이스로 남고(실측), 오류·완료 결과가 운영자 확인까지 화면에 유지됩니다. 취소(`SyncCancelledError`) 흐름은 불변.

## 테스트 결과 / 결과 증빙 (Screenshots / Logs)

- `test_sync_controller.py` + `test_admin.py` 20개 통과(신규 4: 실패 로깅 `exc_info`, 종료 핸드오프, 결과 패널 완료/오류, '확인' 종료).
- 백그라운드 실패 로깅 실측: 실제 모듈 로거(`src.controllers.sync_controller.logger`)로 `exc_info=True` 호출 시 `Traceback (most recent call last)` + 실패 함수 프레임 방출 확인.
- `ruff check` / `ruff format --check` 통과.

전/후 (동기화 오류 발생 시):

```
[전]  st.error("동기화 오류: ...") 표시 → 0.5초 후 다이얼로그 자동 닫힘 → 에러 못 봄
      app.log: (스택트레이스 없음, job.error 문자열만)

[후]  ── 동기화 결과 ──────────────────
      동기화 오류: ingestion boom
      마지막 처리 파일: broken.hwp
      [ 확인 ]                ← 누르기 전까지 유지
      app.log: ERROR ... 백그라운드 동기화 실패 (parser=docling, 최근 파일='broken.hwp')
               Traceback (most recent call last): ...
```

## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요?
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
* [x] 관련 이슈 번호를 연결했나요? (Resolves #201)
* [x] 주간 발표 자료로 활용 가능한 직관적인 결과물(스크린샷/로그)을 첨부했나요?
* [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디

이슈가 지목한 `sync_controller.py:165`(foreground `trigger_sync`)는 현재 production 호출부가 없어(테스트만 사용) 그대로 두고, 실제 자동 닫힘 지점인 admin 백그라운드 폴링 프래그먼트를 수정했습니다. foreground 경로 정리(데드코드 제거)는 별도 논의를 제안합니다.

Resolves #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)
