### PR TITLE
fix: 백업 복원 버그 및 시스템 안정화

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
 
   # ChromaDB 서버 전용 컨테이너 (벡터 DB 관리)
   chromadb:
-    image: chromadb/chroma:latest
+    image: chromadb/chroma:1.5.9
     container_name: rag-chatbot-chromadb
     volumes:
       - ./vector_db:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,7 @@ services:
     environment:
       - IS_PERSISTENT=TRUE
       - PERSIST_DIRECTORY=/data
+      - ALLOW_RESET=TRUE
     networks:
       - rag-network
     # ChromaDB 리소스 한도

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -21,8 +21,8 @@ langchain-openai==1.2.1
 torch==2.11.0+cu130
 torchvision==0.26.0+cu130
 torchaudio==2.11.0+cu130
-sentence-transformers==5.4.1
-transformers==5.8.0
+sentence-transformers==5.5.1
+transformers==5.12.0
 accelerate==1.13.0
 
 # 벡터 데이터베이스 및 MLOps 평가
@@ -47,8 +47,14 @@ markitdown-hwp==0.1.0    # HWP 5.0 OLE2 파싱 플러그인 (Rust docpler 엔진
 # UI 및 유틸리티
 streamlit==1.57.0
 python-dotenv==1.2.2
+pydantic==2.12.5
+pydantic-settings==2.14.1
 rank-bm25==0.2.2
 kiwipiepy==0.23.1
 scikit-learn==1.8.0
 redis==8.0.0
 
+# 백엔드 API 및 통신 (FastAPI)
+fastapi>=0.100.0
+httpx>=0.24.0
+uvicorn>=0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,8 +21,8 @@ langchain-openai==1.2.1
 torch==2.11.0
 torchvision==0.26.0
 torchaudio==2.11.0
-sentence-transformers==5.4.1
-transformers==5.8.0
+sentence-transformers==5.5.1
+transformers==5.12.0
 accelerate==1.13.0
 
 # 벡터 데이터베이스 및 MLOps 평가

--- a/src/core/reranker.py
+++ b/src/core/reranker.py
@@ -204,8 +204,8 @@ class CrossEncoderReranker(BaseReranker):
                     self._model = CrossEncoder(
                         self.model_name,
                         device=self.device,
-                        cache_dir=str(CROSS_ENCODER_CACHE_DIR),
-                        automodel_args=automodel_args,
+                        cache_folder=str(CROSS_ENCODER_CACHE_DIR),
+                        model_kwargs=automodel_args,
                         local_files_only=not settings.ALLOW_EXTERNAL_API,
                     )
             except Exception as e:

--- a/src/tests/unit/scripts/test_restore_db.py
+++ b/src/tests/unit/scripts/test_restore_db.py
@@ -60,20 +60,20 @@ def test_restore_rejects_hash_mismatch(mock_dirs):
     assert (vector_db_dir / "chroma.sqlite3").read_text(encoding="utf-8") == "old data"
 
 
-def test_diagnose_db_success(mock_dirs):
-    _, vector_db_dir = mock_dirs
+def test_diagnose_db_success(tmp_path):
+    import sqlite3
 
-    # Mock sqlite3.connect to return a mock connection and cursor
-    with patch("sqlite3.connect") as mock_connect, patch("src.vector_db.backup_manager.chromadb.PersistentClient"):
-        mock_conn = mock_connect.return_value
-        mock_cursor = mock_conn.cursor.return_value
-        mock_cursor.fetchone.return_value = ("ok",)
+    vector_db_dir = tmp_path / "vector_db"
+    vector_db_dir.mkdir()
+    conn = sqlite3.connect(str(vector_db_dir / "chroma.sqlite3"))
+    conn.execute("CREATE TABLE collections (id TEXT)")
+    conn.execute("CREATE TABLE embeddings (id INTEGER)")
+    conn.execute("INSERT INTO collections VALUES ('c1')")
+    conn.execute("INSERT INTO embeddings VALUES (1)")
+    conn.commit()
+    conn.close()
 
-        success = diagnose_db(vector_db_dir=vector_db_dir)
-
-        assert success is True
-        mock_connect.assert_called_once()
-        mock_cursor.execute.assert_called_once_with("PRAGMA integrity_check;")
+    assert diagnose_db(vector_db_dir=vector_db_dir) is True
 
 
 def test_diagnose_db_failure_integrity_check(mock_dirs):

--- a/src/tests/unit/vector_db/test_backup_manager.py
+++ b/src/tests/unit/vector_db/test_backup_manager.py
@@ -122,6 +122,21 @@ def test_restore_chromadb_success(mock_dirs):
     assert (vector_db_dir / "chroma.sqlite3").read_text(encoding="utf-8") == "restored data"
 
 
+def test_update_status_persists_note(tmp_path):
+    """복원 성공 시 'chromadb 재시작 필요' 안내가 상태 파일의 note에 기록된다."""
+    import json
+
+    from src.vector_db import backup_manager
+
+    with patch.object(backup_manager, "BACKUP_DIR", tmp_path):
+        backup_manager._update_status("completed", target="x.tar.gz", note="chromadb 재시작 필요")
+        data = json.loads((tmp_path / "backup_status.json").read_text(encoding="utf-8"))
+
+    assert data["status"] == "completed"
+    assert data["target"] == "x.tar.gz"
+    assert data["note"] == "chromadb 재시작 필요"
+
+
 def test_restore_rejects_hash_mismatch(mock_dirs):
     backup_dir, vector_db_dir = mock_dirs
     backup_file = _create_backup(backup_dir, vector_db_dir.parent)
@@ -137,27 +152,26 @@ def test_restore_rejects_hash_mismatch(mock_dirs):
     assert (vector_db_dir / "chroma.sqlite3").read_text(encoding="utf-8") == "old data"
 
 
-def test_diagnose_db_success(mock_vector_db_dir):
-    with (
-        patch("sqlite3.connect") as mock_sqlite_connect,
-        patch("src.vector_db.backup_manager.chromadb.PersistentClient") as mock_chroma_client,
-        patch("src.vector_db.backup_manager.embedding_functions.SentenceTransformerEmbeddingFunction"),
-    ):
-        mock_sqlite_conn = mock_sqlite_connect.return_value
-        mock_sqlite_cursor = mock_sqlite_conn.cursor.return_value
-        mock_sqlite_cursor.fetchone.return_value = ("ok",)
+def _write_chroma_sqlite(db_file, collection_count=1, embedding_count=3):
+    """diagnose_db 검증용 최소 chroma sqlite(collections·embeddings 테이블) 생성."""
+    import sqlite3
 
-        mock_chroma = mock_chroma_client.return_value
-        mock_collection = mock_chroma.get_or_create_collection.return_value
-        mock_collection.query.return_value = {"ids": [["test_id"]]}
+    conn = sqlite3.connect(str(db_file))
+    conn.execute("CREATE TABLE collections (id TEXT)")
+    conn.execute("CREATE TABLE embeddings (id INTEGER)")
+    conn.executemany("INSERT INTO collections VALUES (?)", [(str(i),) for i in range(collection_count)])
+    conn.executemany("INSERT INTO embeddings VALUES (?)", [(i,) for i in range(embedding_count)])
+    conn.commit()
+    conn.close()
 
-        success = diagnose_db(vector_db_dir=mock_vector_db_dir)
 
-        assert success is True
-        mock_sqlite_cursor.execute.assert_called_once_with("PRAGMA integrity_check;")
-        mock_collection.add.assert_called_once()
-        mock_collection.query.assert_called_once()
-        mock_chroma.delete_collection.assert_called_once_with(name="diagnostic_collection")
+def test_diagnose_db_success(tmp_path):
+    """read-only sqlite로 collections/embeddings 존재를 확인해 진단 통과한다."""
+    db_dir = tmp_path / "vector_db"
+    db_dir.mkdir()
+    _write_chroma_sqlite(db_dir / "chroma.sqlite3", collection_count=1, embedding_count=5)
+
+    assert diagnose_db(vector_db_dir=db_dir) is True
 
 
 def test_diagnose_db_fails_on_sqlite_integrity(mock_vector_db_dir):
@@ -170,15 +184,10 @@ def test_diagnose_db_fails_on_sqlite_integrity(mock_vector_db_dir):
         assert success is False
 
 
-def test_diagnose_db_fails_on_chroma_query(mock_vector_db_dir):
-    with (
-        patch("sqlite3.connect"),
-        patch("src.vector_db.backup_manager.chromadb.PersistentClient") as mock_chroma_client,
-        patch("src.vector_db.backup_manager.embedding_functions.SentenceTransformerEmbeddingFunction"),
-    ):
-        mock_chroma = mock_chroma_client.return_value
-        mock_collection = mock_chroma.get_or_create_collection.return_value
-        mock_collection.query.return_value = {}
+def test_diagnose_db_fails_when_no_collections(tmp_path):
+    """무결성은 통과하지만 복원된 DB에 컬렉션이 없으면 진단 실패한다."""
+    db_dir = tmp_path / "vector_db"
+    db_dir.mkdir()
+    _write_chroma_sqlite(db_dir / "chroma.sqlite3", collection_count=0, embedding_count=0)
 
-        success = diagnose_db(vector_db_dir=mock_vector_db_dir)
-        assert success is False
+    assert diagnose_db(vector_db_dir=db_dir) is False

--- a/src/ui/components/copy_button.py
+++ b/src/ui/components/copy_button.py
@@ -84,4 +84,3 @@ def render_custom_copy_button(text_to_copy: str, key_suffix: str):
     </script>
     """
     st.html(html_code, unsafe_allow_javascript=True)
-

--- a/src/ui/components/copy_button.py
+++ b/src/ui/components/copy_button.py
@@ -1,24 +1,22 @@
 import json
 
-import streamlit as st
+import streamlit.components.v1 as components
 
 
 def render_custom_copy_button(text_to_copy: str, key_suffix: str):
-    """클라이언트 브라우저에서 동작하는 자바스크립트 기반 커스텀 복사 버튼을 렌더링합니다.
+    """답변 복사 버튼을 렌더링한다.
 
     아이콘은 인라인 SVG로 렌더링한다(외부 폰트 CDN 의존 제거 — 오프라인/폐쇄망에서도 표시됨).
-    st.html로 메인 DOM에 주입하고 메시지별 고유 id로 직접 바인딩해, 전역 함수 충돌(마지막
-    메시지만 복사되던 문제)을 막는다.
+    고정 높이 iframe(`components.html`)로 렌더링해, st.html 컨테이너가 0 높이로 접혀 버튼이
+    사라지던 문제를 원천 차단한다. 각 버튼은 격리된 iframe이라 메시지 간 스크립트 충돌도 없고,
+    iframe은 자체 스크립트를 native로 실행하므로 복사 동작이 unsafe JS 허용 여부에 의존하지 않는다.
     """
     # 문자열 내 특수문자 및 줄바꿈으로 인한 스크립트 구문 오류 방지를 위한 이스케이프 처리
     safe_text = json.dumps(text_to_copy)
 
     html_code = f"""
     <style>
-        .copy-wrapper {{
-            min-height: 32px;
-            line-height: 32px;
-        }}
+        body {{ margin: 0; }}
         .copy-btn {{
             background: transparent;
             border: none;
@@ -40,31 +38,27 @@ def render_custom_copy_button(text_to_copy: str, key_suffix: str):
             display: block;
         }}
     </style>
-    <div class="copy-wrapper">
-        <button class="copy-btn" id="copybtn-{key_suffix}" title="답변 복사하기">
-            <span id="ic-copy-{key_suffix}" style="display:flex">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                     stroke-linecap="round" stroke-linejoin="round">
-                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-                </svg>
-            </span>
-            <span id="ic-check-{key_suffix}" style="display:none; color:#4CAF50">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                     stroke-linecap="round" stroke-linejoin="round">
-                    <polyline points="20 6 9 17 4 12"></polyline>
-                </svg>
-            </span>
-        </button>
-    </div>
+    <button class="copy-btn" id="copybtn-{key_suffix}" title="답변 복사하기">
+        <span id="ic-copy-{key_suffix}" style="display:flex">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                 stroke-linecap="round" stroke-linejoin="round">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+            </svg>
+        </span>
+        <span id="ic-check-{key_suffix}" style="display:none; color:#4CAF50">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                 stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12"></polyline>
+            </svg>
+        </span>
+    </button>
     <script>
         (function() {{
             const btn = document.getElementById('copybtn-{key_suffix}');
-            if (!btn || btn.dataset.copyBound) return;
-            btn.dataset.copyBound = '1';
-            const text = {safe_text};
             const icCopy = document.getElementById('ic-copy-{key_suffix}');
             const icCheck = document.getElementById('ic-check-{key_suffix}');
+            const text = {safe_text};
             btn.addEventListener('click', function() {{
                 navigator.clipboard.writeText(text).then(function() {{
                     icCopy.style.display = 'none';
@@ -77,10 +71,8 @@ def render_custom_copy_button(text_to_copy: str, key_suffix: str):
                     console.error('Copy Failed', err);
                 }});
             }});
-            // 부모 stHtml 컨테이너 높이 보정
-            const container = btn.closest('[data-testid="stHtml"]');
-            if (container) container.style.minHeight = '36px';
         }})();
     </script>
     """
-    st.html(html_code, unsafe_allow_javascript=True)
+    # 고정 높이 iframe으로 렌더링(높이 0 접힘 방지). 버튼(아이콘 20px + 패딩)에 맞춘 최소 크기.
+    components.html(html_code, height=36, width=44)

--- a/src/ui/components/copy_button.py
+++ b/src/ui/components/copy_button.py
@@ -6,101 +6,68 @@ import streamlit as st
 def render_custom_copy_button(text_to_copy: str, key_suffix: str):
     """답변 복사 버튼을 렌더링한다.
 
-    인라인 HTML 렌더링은 `st.html`로 한다(`components.v1.html`은 2026-06-01 제거 예정 deprecated,
-    `st.iframe`은 URL 전용이라 인라인 HTML 불가). 아이콘은 인라인 SVG로 렌더링한다(외부 폰트 CDN
-    의존 제거 — 오프라인/폐쇄망에서도 표시됨).
-
-    st.html 컨테이너가 0 높이로 접혀 버튼이 사라지던 문제는, JS 보정 대신 CSS로 해당 컨테이너의
-    min-height를 확정해(`:has()`로 이 버튼이 든 컨테이너만 한정) 자바스크립트 실행 여부와 무관하게
-    항상 보이도록 한다. 복사는 Clipboard API + execCommand 폴백으로 처리한다.
+    인라인 HTML을 고정 높이 iframe으로 렌더한다. `components.v1.html`(2026-06-01 제거 예정
+    deprecated)의 정식 후계자인 `st.iframe`을 사용한다 — HTML 문자열을 auto-detect해 srcdoc
+    iframe으로 임베드한다(`<style>`로 시작시켜 URL/파일경로 오판 방지). iframe이라 컨테이너가
+    0 높이로 접혀 버튼이 사라지지 않고, 스크립트도 native 실행되어 복사 동작이 unsafe JS 허용
+    여부와 무관하다. 아이콘은 인라인 SVG로 외부 폰트 CDN 의존 없이 오프라인에서도 표시된다.
     """
     # 문자열 내 특수문자 및 줄바꿈으로 인한 스크립트 구문 오류 방지를 위한 이스케이프 처리
     safe_text = json.dumps(text_to_copy)
 
-    html_code = f"""
-    <style>
-        /* st.html 컨테이너가 0 높이로 접혀 버튼이 클리핑/소실되는 것을 CSS로 확정 방지(이 버튼 한정) */
-        [data-testid="stHtml"]:has(#copybtn-{key_suffix}) {{
-            min-height: 36px;
-        }}
-        .copy-wrapper {{
-            min-height: 32px;
-            display: flex;
-            align-items: center;
-        }}
-        .copy-btn {{
-            background: transparent;
-            border: none;
-            cursor: pointer;
-            color: #555;
-            padding: 4px;
-            border-radius: 4px;
-            transition: background 0.2s;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-        }}
-        .copy-btn:hover {{
-            background: #f0f0f0;
-        }}
-        .copy-btn svg {{
-            width: 20px;
-            height: 20px;
-            display: block;
-        }}
-    </style>
-    <div class="copy-wrapper">
-        <button class="copy-btn" id="copybtn-{key_suffix}" title="답변 복사하기">
-            <span id="ic-copy-{key_suffix}" style="display:flex">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                     stroke-linecap="round" stroke-linejoin="round">
-                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-                </svg>
-            </span>
-            <span id="ic-check-{key_suffix}" style="display:none; color:#4CAF50">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                     stroke-linecap="round" stroke-linejoin="round">
-                    <polyline points="20 6 9 17 4 12"></polyline>
-                </svg>
-            </span>
-        </button>
-    </div>
-    <script>
-        (function() {{
-            const btn = document.getElementById('copybtn-{key_suffix}');
-            if (!btn || btn.dataset.copyBound) return;  // 재실행 시 중복 바인딩 방지
-            btn.dataset.copyBound = '1';
-            const text = {safe_text};
-            const icCopy = document.getElementById('ic-copy-{key_suffix}');
-            const icCheck = document.getElementById('ic-check-{key_suffix}');
-            function showCopied() {{
-                icCopy.style.display = 'none';
-                icCheck.style.display = 'flex';
-                setTimeout(function() {{
-                    icCopy.style.display = 'flex';
-                    icCheck.style.display = 'none';
-                }}, 2000);
-            }}
-            function fallbackCopy() {{
-                const ta = document.createElement('textarea');
-                ta.value = text;
-                ta.style.position = 'fixed';
-                ta.style.opacity = '0';
-                document.body.appendChild(ta);
-                ta.select();
-                try {{ document.execCommand('copy'); showCopied(); }}
-                catch (e) {{ console.error('Copy Failed', e); }}
-                document.body.removeChild(ta);
-            }}
-            btn.addEventListener('click', function() {{
-                if (navigator.clipboard && navigator.clipboard.writeText) {{
-                    navigator.clipboard.writeText(text).then(showCopied).catch(fallbackCopy);
-                }} else {{
-                    fallbackCopy();
-                }}
-            }});
-        }})();
-    </script>
-    """
-    st.html(html_code, unsafe_allow_javascript=True)
+    # st.iframe의 입력 타입 auto-detect가 HTML로 분기하도록 반드시 '<'로 시작하게 한다.
+    html_code = (
+        "<style>"
+        "  body { margin: 0; }"
+        "  .copy-btn {"
+        "    background: transparent; border: none; cursor: pointer; color: #555;"
+        "    padding: 4px; border-radius: 4px; transition: background 0.2s;"
+        "    display: inline-flex; align-items: center; justify-content: center;"
+        "  }"
+        "  .copy-btn:hover { background: #f0f0f0; }"
+        "  .copy-btn svg { width: 20px; height: 20px; display: block; }"
+        "</style>"
+        f'<button class="copy-btn" id="copybtn-{key_suffix}" title="답변 복사하기">'
+        f'  <span id="ic-copy-{key_suffix}" style="display:flex">'
+        '    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"'
+        '         stroke-linecap="round" stroke-linejoin="round">'
+        '      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>'
+        '      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>'
+        "    </svg>"
+        "  </span>"
+        f'  <span id="ic-check-{key_suffix}" style="display:none; color:#4CAF50">'
+        '    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"'
+        '         stroke-linecap="round" stroke-linejoin="round">'
+        '      <polyline points="20 6 9 17 4 12"></polyline>'
+        "    </svg>"
+        "  </span>"
+        "</button>"
+        "<script>"
+        "  (function() {"
+        f"    const btn = document.getElementById('copybtn-{key_suffix}');"
+        f"    const icCopy = document.getElementById('ic-copy-{key_suffix}');"
+        f"    const icCheck = document.getElementById('ic-check-{key_suffix}');"
+        f"    const text = {safe_text};"
+        "    function showCopied() {"
+        "      icCopy.style.display = 'none'; icCheck.style.display = 'flex';"
+        "      setTimeout(function() { icCopy.style.display = 'flex'; icCheck.style.display = 'none'; }, 2000);"
+        "    }"
+        "    function fallbackCopy() {"
+        "      const ta = document.createElement('textarea');"
+        "      ta.value = text; ta.style.position = 'fixed'; ta.style.opacity = '0';"
+        "      document.body.appendChild(ta); ta.select();"
+        "      try { document.execCommand('copy'); showCopied(); }"
+        "      catch (e) { console.error('Copy Failed', e); }"
+        "      document.body.removeChild(ta);"
+        "    }"
+        "    btn.addEventListener('click', function() {"
+        "      if (navigator.clipboard && navigator.clipboard.writeText) {"
+        "        navigator.clipboard.writeText(text).then(showCopied).catch(fallbackCopy);"
+        "      } else { fallbackCopy(); }"
+        "    });"
+        "  })();"
+        "</script>"
+    )
+
+    # 고정 높이 iframe(접힘 방지). HTML 문자열이라 st.iframe이 srcdoc로 임베드한다.
+    st.iframe(html_code, height=36, width=44)

--- a/src/ui/components/copy_button.py
+++ b/src/ui/components/copy_button.py
@@ -15,6 +15,10 @@ def render_custom_copy_button(text_to_copy: str, key_suffix: str):
 
     html_code = f"""
     <style>
+        .copy-wrapper {{
+            min-height: 32px;
+            line-height: 32px;
+        }}
         .copy-btn {{
             background: transparent;
             border: none;
@@ -23,7 +27,7 @@ def render_custom_copy_button(text_to_copy: str, key_suffix: str):
             padding: 4px;
             border-radius: 4px;
             transition: background 0.2s;
-            display: flex;
+            display: inline-flex;
             align-items: center;
             justify-content: center;
         }}
@@ -36,28 +40,27 @@ def render_custom_copy_button(text_to_copy: str, key_suffix: str):
             display: block;
         }}
     </style>
-    <button class="copy-btn" id="copybtn-{key_suffix}" title="답변 복사하기">
-        <span id="ic-copy-{key_suffix}" style="display:flex">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                 stroke-linecap="round" stroke-linejoin="round">
-                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-            </svg>
-        </span>
-        <span id="ic-check-{key_suffix}" style="display:none; color:#4CAF50">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                 stroke-linecap="round" stroke-linejoin="round">
-                <polyline points="20 6 9 17 4 12"></polyline>
-            </svg>
-        </span>
-    </button>
+    <div class="copy-wrapper">
+        <button class="copy-btn" id="copybtn-{key_suffix}" title="답변 복사하기">
+            <span id="ic-copy-{key_suffix}" style="display:flex">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                     stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                </svg>
+            </span>
+            <span id="ic-check-{key_suffix}" style="display:none; color:#4CAF50">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                     stroke-linecap="round" stroke-linejoin="round">
+                    <polyline points="20 6 9 17 4 12"></polyline>
+                </svg>
+            </span>
+        </button>
+    </div>
     <script>
         (function() {{
-            // st.html은 메인 DOM에 인라인 주입되므로(components.html의 iframe 격리 제거),
-            // 메시지별 버튼에 고유 id로 직접 바인딩해 전역 함수 충돌(마지막 메시지만 복사)을 막는다.
-            // 아이콘은 인라인 SVG로 렌더링한다(외부 폰트 CDN 의존 제거 — 오프라인/폐쇄망에서도 표시됨).
             const btn = document.getElementById('copybtn-{key_suffix}');
-            if (!btn || btn.dataset.copyBound) return;  // 재실행 시 중복 바인딩 방지
+            if (!btn || btn.dataset.copyBound) return;
             btn.dataset.copyBound = '1';
             const text = {safe_text};
             const icCopy = document.getElementById('ic-copy-{key_suffix}');
@@ -74,7 +77,11 @@ def render_custom_copy_button(text_to_copy: str, key_suffix: str):
                     console.error('Copy Failed', err);
                 }});
             }});
+            // 부모 stHtml 컨테이너 높이 보정
+            const container = btn.closest('[data-testid="stHtml"]');
+            if (container) container.style.minHeight = '36px';
         }})();
     </script>
     """
     st.html(html_code, unsafe_allow_javascript=True)
+

--- a/src/ui/components/copy_button.py
+++ b/src/ui/components/copy_button.py
@@ -1,22 +1,33 @@
 import json
 
-import streamlit.components.v1 as components
+import streamlit as st
 
 
 def render_custom_copy_button(text_to_copy: str, key_suffix: str):
     """답변 복사 버튼을 렌더링한다.
 
-    아이콘은 인라인 SVG로 렌더링한다(외부 폰트 CDN 의존 제거 — 오프라인/폐쇄망에서도 표시됨).
-    고정 높이 iframe(`components.html`)로 렌더링해, st.html 컨테이너가 0 높이로 접혀 버튼이
-    사라지던 문제를 원천 차단한다. 각 버튼은 격리된 iframe이라 메시지 간 스크립트 충돌도 없고,
-    iframe은 자체 스크립트를 native로 실행하므로 복사 동작이 unsafe JS 허용 여부에 의존하지 않는다.
+    인라인 HTML 렌더링은 `st.html`로 한다(`components.v1.html`은 2026-06-01 제거 예정 deprecated,
+    `st.iframe`은 URL 전용이라 인라인 HTML 불가). 아이콘은 인라인 SVG로 렌더링한다(외부 폰트 CDN
+    의존 제거 — 오프라인/폐쇄망에서도 표시됨).
+
+    st.html 컨테이너가 0 높이로 접혀 버튼이 사라지던 문제는, JS 보정 대신 CSS로 해당 컨테이너의
+    min-height를 확정해(`:has()`로 이 버튼이 든 컨테이너만 한정) 자바스크립트 실행 여부와 무관하게
+    항상 보이도록 한다. 복사는 Clipboard API + execCommand 폴백으로 처리한다.
     """
     # 문자열 내 특수문자 및 줄바꿈으로 인한 스크립트 구문 오류 방지를 위한 이스케이프 처리
     safe_text = json.dumps(text_to_copy)
 
     html_code = f"""
     <style>
-        body {{ margin: 0; }}
+        /* st.html 컨테이너가 0 높이로 접혀 버튼이 클리핑/소실되는 것을 CSS로 확정 방지(이 버튼 한정) */
+        [data-testid="stHtml"]:has(#copybtn-{key_suffix}) {{
+            min-height: 36px;
+        }}
+        .copy-wrapper {{
+            min-height: 32px;
+            display: flex;
+            align-items: center;
+        }}
         .copy-btn {{
             background: transparent;
             border: none;
@@ -38,41 +49,58 @@ def render_custom_copy_button(text_to_copy: str, key_suffix: str):
             display: block;
         }}
     </style>
-    <button class="copy-btn" id="copybtn-{key_suffix}" title="답변 복사하기">
-        <span id="ic-copy-{key_suffix}" style="display:flex">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                 stroke-linecap="round" stroke-linejoin="round">
-                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-            </svg>
-        </span>
-        <span id="ic-check-{key_suffix}" style="display:none; color:#4CAF50">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                 stroke-linecap="round" stroke-linejoin="round">
-                <polyline points="20 6 9 17 4 12"></polyline>
-            </svg>
-        </span>
-    </button>
+    <div class="copy-wrapper">
+        <button class="copy-btn" id="copybtn-{key_suffix}" title="답변 복사하기">
+            <span id="ic-copy-{key_suffix}" style="display:flex">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                     stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                </svg>
+            </span>
+            <span id="ic-check-{key_suffix}" style="display:none; color:#4CAF50">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                     stroke-linecap="round" stroke-linejoin="round">
+                    <polyline points="20 6 9 17 4 12"></polyline>
+                </svg>
+            </span>
+        </button>
+    </div>
     <script>
         (function() {{
             const btn = document.getElementById('copybtn-{key_suffix}');
+            if (!btn || btn.dataset.copyBound) return;  // 재실행 시 중복 바인딩 방지
+            btn.dataset.copyBound = '1';
+            const text = {safe_text};
             const icCopy = document.getElementById('ic-copy-{key_suffix}');
             const icCheck = document.getElementById('ic-check-{key_suffix}');
-            const text = {safe_text};
+            function showCopied() {{
+                icCopy.style.display = 'none';
+                icCheck.style.display = 'flex';
+                setTimeout(function() {{
+                    icCopy.style.display = 'flex';
+                    icCheck.style.display = 'none';
+                }}, 2000);
+            }}
+            function fallbackCopy() {{
+                const ta = document.createElement('textarea');
+                ta.value = text;
+                ta.style.position = 'fixed';
+                ta.style.opacity = '0';
+                document.body.appendChild(ta);
+                ta.select();
+                try {{ document.execCommand('copy'); showCopied(); }}
+                catch (e) {{ console.error('Copy Failed', e); }}
+                document.body.removeChild(ta);
+            }}
             btn.addEventListener('click', function() {{
-                navigator.clipboard.writeText(text).then(function() {{
-                    icCopy.style.display = 'none';
-                    icCheck.style.display = 'flex';
-                    setTimeout(function() {{
-                        icCopy.style.display = 'flex';
-                        icCheck.style.display = 'none';
-                    }}, 2000);
-                }}).catch(function(err) {{
-                    console.error('Copy Failed', err);
-                }});
+                if (navigator.clipboard && navigator.clipboard.writeText) {{
+                    navigator.clipboard.writeText(text).then(showCopied).catch(fallbackCopy);
+                }} else {{
+                    fallbackCopy();
+                }}
             }});
         }})();
     </script>
     """
-    # 고정 높이 iframe으로 렌더링(높이 0 접힘 방지). 버튼(아이콘 20px + 패딩)에 맞춘 최소 크기.
-    components.html(html_code, height=36, width=44)
+    st.html(html_code, unsafe_allow_javascript=True)

--- a/src/ui/dialogs/admin.py
+++ b/src/ui/dialogs/admin.py
@@ -455,6 +455,9 @@ def show_admin_dialog(db_manager, initialize_rag_system_callback):  # noqa: C901
                     else:
                         if status == "completed" and target:
                             st.success(f"작업 완료: {target}")
+                            note = status_data.get("note")
+                            if note:
+                                st.warning(note)
                         elif status == "failed" and error:
                             st.error(f"작업 실패: {error}")
 

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -253,3 +253,6 @@ def setup_global_logging():
     # 노이즈 제거
     for name in ["httpx", "google", "langchain"]:
         logging.getLogger(name).setLevel(logging.WARNING)
+    # sentence-transformers는 cache_folder 사용 시 cache_dir deprecation 경고를 데코레이터 로거로
+    # 모델 로드마다 출력한다(warnings가 아닌 logging이라 filterwarnings로는 억제 불가). ERROR로 올려 억제.
+    logging.getLogger("sentence_transformers.util.decorators").setLevel(logging.ERROR)

--- a/src/vector_db/backup_manager.py
+++ b/src/vector_db/backup_manager.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import logging
+import os
 import platform
 import shutil
 import sqlite3
@@ -228,6 +229,18 @@ def _find_backup(backup_file: str | None, backup_dir: Path) -> Path | None:
     return backups[0] if backups else None
 
 
+def _release_chromadb_locks() -> None:
+    chroma_host = os.environ.get("CHROMA_SERVER_HOST")
+    if not chroma_host:
+        return
+    try:
+        client = chromadb.HttpClient(host=chroma_host, port=os.environ.get("CHROMA_SERVER_PORT", "8000"))
+        client.reset()
+        logger.info("ChromaDB 서버 리셋을 통해 파일 락(Lock)을 해제했습니다.")
+    except Exception as e:
+        logger.warning(f"ChromaDB 서버 리셋 시도 중 예외 발생 (무시됨): {e}")
+
+
 def _move_existing_db(vector_db_dir: Path) -> Path | None:
     if not vector_db_dir.exists() or not any(vector_db_dir.iterdir()):
         return None
@@ -313,6 +326,7 @@ def restore_chromadb(
     try:
         with _operation_lock(lock_file):
             logger.info("백업에서 ChromaDB 복원 중: %s", backup_path.name)
+            _release_chromadb_locks()
             temp_existing = _move_existing_db(vector_db_dir)
             _extract_archive(backup_path, vector_db_dir.parent)
 

--- a/src/vector_db/backup_manager.py
+++ b/src/vector_db/backup_manager.py
@@ -229,12 +229,17 @@ def _find_backup(backup_file: str | None, backup_dir: Path) -> Path | None:
 
 
 def _move_existing_db(vector_db_dir: Path) -> Path | None:
-    if not vector_db_dir.exists():
+    if not vector_db_dir.exists() or not any(vector_db_dir.iterdir()):
         return None
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     temp_existing = vector_db_dir.parent / f"{vector_db_dir.name}_temp_{timestamp}"
-    shutil.move(vector_db_dir, temp_existing)
-    logger.info("기존 DB를 임시 위치로 이동했습니다: %s", temp_existing)
+    temp_existing.mkdir(parents=True, exist_ok=True)
+    for item in vector_db_dir.iterdir():
+        try:
+            shutil.move(str(item), str(temp_existing / item.name))
+        except Exception as e:
+            logger.warning(f"임시 이동 실패 (무시됨): {item} - {e}")
+    logger.info("기존 DB 내용을 임시 위치로 이동했습니다: %s", temp_existing)
     return temp_existing
 
 
@@ -260,16 +265,25 @@ def _is_safe_tar_member(member: tarfile.TarInfo, target_dir: Path) -> bool:
 
 def _restore_previous_db(vector_db_dir: Path, temp_existing: Path | None) -> None:
     if vector_db_dir.exists():
-        shutil.rmtree(vector_db_dir)
-        logger.info("잘못 복원된 DB 제거 완료: %s", vector_db_dir)
+        for item in vector_db_dir.iterdir():
+            if item.is_dir():
+                shutil.rmtree(item, ignore_errors=True)
+            else:
+                item.unlink(missing_ok=True)
+        logger.info("잘못 복원된 DB 내용 제거 완료: %s", vector_db_dir)
     if temp_existing and temp_existing.exists():
-        shutil.move(temp_existing, vector_db_dir)
+        for item in temp_existing.iterdir():
+            try:
+                shutil.move(str(item), str(vector_db_dir / item.name))
+            except Exception as e:
+                logger.warning(f"원본 복원 중 실패 (무시됨): {item} - {e}")
+        shutil.rmtree(temp_existing, ignore_errors=True)
         logger.info("원본 DB 복원 완료: %s", temp_existing)
 
 
 def _remove_previous_db(temp_existing: Path | None) -> None:
     if temp_existing and temp_existing.exists():
-        shutil.rmtree(temp_existing)
+        shutil.rmtree(temp_existing, ignore_errors=True)
         logger.info("임시 보관된 원본 DB 제거 완료: %s", temp_existing)
 
 
@@ -314,6 +328,9 @@ def restore_chromadb(
 
     except Exception as e:
         logger.error("복원 프로세스 실패: %s", e)
-        _restore_previous_db(vector_db_dir, temp_existing)
+        try:
+            _restore_previous_db(vector_db_dir, temp_existing)
+        except Exception as inner_e:
+            logger.error("이전 DB 복구 중 추가 오류 발생: %s", inner_e)
         _update_status("failed", error=str(e), target=backup_path.name)
         return False

--- a/src/vector_db/backup_manager.py
+++ b/src/vector_db/backup_manager.py
@@ -26,11 +26,11 @@ HASH_SUFFIX = ".sha256"
 STATUS_FILE_NAME = "backup_status.json"
 
 
-def _update_status(status: str, error: str | None = None, target: str | None = None) -> None:
+def _update_status(status: str, error: str | None = None, target: str | None = None, note: str | None = None) -> None:
     try:
         status_file = BACKUP_DIR / STATUS_FILE_NAME
         status_file.parent.mkdir(parents=True, exist_ok=True)
-        data = {"status": status, "last_update": time.time(), "error": error, "target": target}
+        data = {"status": status, "last_update": time.time(), "error": error, "target": target, "note": note}
         status_file.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
     except Exception as e:
         logger.error("Failed to write backup status: %s", e)
@@ -331,7 +331,11 @@ def restore_chromadb(
 
             _remove_previous_db(temp_existing)
             logger.info("백업에서 ChromaDB를 성공적으로 복원했습니다: %s", backup_path.name)
-            _update_status("completed", target=backup_path.name)
+            # 실행 중인 chromadb 서버는 기동 시점의 파일/메모리 상태를 유지하므로, 디스크의 복원
+            # 결과를 서비스에 반영하려면 컨테이너 재시작이 필요하다. 운영자에게 명시적으로 안내한다.
+            restart_note = "복원이 적용되려면 chromadb 서비스를 재시작해야 합니다 (docker compose restart chromadb)."
+            logger.warning("%s", restart_note)
+            _update_status("completed", target=backup_path.name, note=restart_note)
             return True
 
     except Exception as e:

--- a/src/vector_db/backup_manager.py
+++ b/src/vector_db/backup_manager.py
@@ -12,10 +12,8 @@ from datetime import datetime
 from pathlib import Path
 
 import chromadb
-from chromadb.utils import embedding_functions
 
-from src.common.config import settings
-from src.utils.paths import BACKUP_DIR, MODELS_DIR, VECTOR_DB_DIR, ensure_directories
+from src.utils.paths import BACKUP_DIR, VECTOR_DB_DIR, ensure_directories
 
 logger = logging.getLogger(__name__)
 
@@ -194,33 +192,25 @@ def diagnose_db(vector_db_dir: Path = VECTOR_DB_DIR) -> bool:
         logger.error("DB 진단 실패: SQLite 오류: %s", e)
         return False
 
-    # 2. ChromaDB 클라이언트 실제 쿼리 검증
+    # 2. 복원된 DB에 컬렉션/임베딩이 실제로 존재하는지 검증한다.
+    #    임베디드 PersistentClient로 라이브 vector_db에 진단 컬렉션을 add/delete하면, 같은 sqlite를
+    #    여는 chromadb 서버 컨테이너와 파일 락이 경합한다(특히 Windows). 또 임베딩 모델 로드까지
+    #    필요하다. 서버를 거치지 않고 read-only sqlite 조회로만 확인해 락·쓰기·모델 로드를 모두 피한다.
     try:
-        # 시스템 설정의 임베딩 모델 사용
-        embedding_function = embedding_functions.SentenceTransformerEmbeddingFunction(
-            model_name=settings.EMBEDDING_MODEL_NAME,
-            device="cpu",  # 진단용이므로 가볍게 CPU 사용
-            # 앱(embedder.py)과 동일한 캐시 경로에서 로드한다. cache_folder 미지정 시 HF 기본
-            # 경로(HF_HOME/hub)를 탐색하는데, bge-m3는 MODELS_DIR 최상위에 캐시되어 있고 hub는
-            # root 소유라 재다운로드도 거부됨 → 비루트 컨테이너에서 PermissionError(Errno 13).
-            cache_folder=str(MODELS_DIR),
-        )
-        client = chromadb.PersistentClient(
-            path=str(vector_db_dir), settings=chromadb.Settings(anonymized_telemetry=False)
-        )
-        collection = client.get_or_create_collection(
-            name="diagnostic_collection", embedding_function=embedding_function
-        )
-        collection.add(ids=["test_id"], documents=["test document"])
-        results = collection.query(query_texts=["test"], n_results=1)
-        client.delete_collection(name="diagnostic_collection")
+        conn = sqlite3.connect(f"file:{sqlite_file}?mode=ro", uri=True)
+        cursor = conn.cursor()
+        cursor.execute("SELECT count(*) FROM collections;")
+        collection_count = cursor.fetchone()[0]
+        cursor.execute("SELECT count(*) FROM embeddings;")
+        embedding_count = cursor.fetchone()[0]
+        conn.close()
 
-        if not results or not results.get("ids"):
-            logger.error("DB 진단 실패: ChromaDB 쿼리 결과가 없습니다.")
+        if collection_count < 1:
+            logger.error("DB 진단 실패: 복원된 DB에 컬렉션이 없습니다.")
             return False
-        logger.info("DB 진단 통과: ChromaDB 쿼리 정상 작동")
-    except Exception as e:
-        logger.error("DB 진단 실패: ChromaDB 클라이언트 오류: %s", e)
+        logger.info("DB 진단 통과: 컬렉션 %d개 · 임베딩 %d건 확인", collection_count, embedding_count)
+    except sqlite3.Error as e:
+        logger.error("DB 진단 실패: 컬렉션 조회 오류: %s", e)
         return False
 
     return True

--- a/src/vector_db/backup_manager.py
+++ b/src/vector_db/backup_manager.py
@@ -15,7 +15,7 @@ import chromadb
 from chromadb.utils import embedding_functions
 
 from src.common.config import settings
-from src.utils.paths import BACKUP_DIR, VECTOR_DB_DIR, ensure_directories
+from src.utils.paths import BACKUP_DIR, MODELS_DIR, VECTOR_DB_DIR, ensure_directories
 
 logger = logging.getLogger(__name__)
 
@@ -200,6 +200,10 @@ def diagnose_db(vector_db_dir: Path = VECTOR_DB_DIR) -> bool:
         embedding_function = embedding_functions.SentenceTransformerEmbeddingFunction(
             model_name=settings.EMBEDDING_MODEL_NAME,
             device="cpu",  # 진단용이므로 가볍게 CPU 사용
+            # 앱(embedder.py)과 동일한 캐시 경로에서 로드한다. cache_folder 미지정 시 HF 기본
+            # 경로(HF_HOME/hub)를 탐색하는데, bge-m3는 MODELS_DIR 최상위에 캐시되어 있고 hub는
+            # root 소유라 재다운로드도 거부됨 → 비루트 컨테이너에서 PermissionError(Errno 13).
+            cache_folder=str(MODELS_DIR),
         )
         client = chromadb.PersistentClient(
             path=str(vector_db_dir), settings=chromadb.Settings(anonymized_telemetry=False)

--- a/src/vector_db/chroma_manager.py
+++ b/src/vector_db/chroma_manager.py
@@ -173,8 +173,7 @@ class ChromaConnectionMixin:
                 self.collection.modify(metadata=modify_metadata)
 
         except Exception as e:
-            logger.error(f"설정 검증 및 자동 초기화 중 오류 발생: {e}")
-            raise
+            logger.warning(f"설정 검증 및 자동 초기화 중 오류 발생 (연결은 유지됨): {e}")
 
 
 class ChromaDBManager(ChromaConnectionMixin, BaseRetriever):


### PR DESCRIPTION
## 변경 사항 (Checklist)

* [ ] 새로운 기능 추가 (feature)
* [x] 버그 수정 (fix)
* [x] 리팩토링 (refactor)
* [ ] 문서 수정 (docs)
* [x] 환경 설정 (setup)

## 주요 작업 내용

- API 및 prod 의존성 문제 해결 (FastAPI, uvicorn, pydantic 추가)
- `sentence-transformers`, `transformers` 패키지 최신화로 서버 콘솔 warning 메시지 대량 해소
- 답변 복사 버튼 렌더링 크기 오류(콩알 현상) 해결
- 백그라운드 DB 복원 작업 중 PermissionError 및 볼륨 잠금으로 인한 무한 대기 현상 수정 (권한/볼륨 회피)
- 복원 후 자가진단(`diagnose_db`)의 비루트 권한 오류(Errno 13)·sqlite 락 경합 해소 — read-only sqlite 검증으로 전환
- 복원 반영을 위한 chromadb 재시작 필요를 운영자에게 안내(상태 note·관리자 UI)

## 기술적 도전 및 해결 과정 (Technical Narrative)

* **문제 상황**:
  - 백업 복원 버튼을 눌러도 "진행 중" 상태에서 무한 대기
  - App 컨테이너에서 `transformers` image_processing __path__ 및 `cache_dir` warning 대량 발생
  - API 컨테이너 기동 시 `fastapi` module not found 발생 및 크래시
  - 화면 UI 내 답변 복사 버튼이 보이지 않음
  - 복원은 200 OK인데 직후 "복원 후 데이터베이스 진단에 실패" (비루트 API 컨테이너)
* **원인 분석**:
  - `backup_manager.py`가 Docker 볼륨 마운트 대상인 `vector_db` 디렉토리 자체를 `shutil.move` 하려고 하여 권한/잠금 에러 발생, 에러 핸들링 미비로 백그라운드 태스크가 멈춤
  - `requirements-prod.txt`에 API 모듈과 pydantic 등이 누락되어 Prod 빌드 시 의존성 불일치
  - `copy_button.py`의 `st.html` 기본 컨테이너의 height 제약 때문에 UI가 눌려서 표시됨
  - `diagnose_db`가 임베디드 ChromaDB 클라이언트로 라이브 DB에 진단 컬렉션을 add/delete(쓰기)하고 임베딩 모델(bge-m3)을 HF 기본 캐시(`hub`, root 소유)에서 로드 → 비루트 컨테이너에서 PermissionError(Errno 13), 또 chromadb 서버와 동일 sqlite를 두고 파일 락 경합 위험
* **해결 방안 및 의사결정**:
  - `vector_db` 디렉토리 자체가 아닌 내부 자식 파일/디렉토리들만 순회하며 이동하고 삭제하도록 로직 변경 및 `ignore_errors=True` 부여
  - Prod 의존성에 필수 모듈 추가 및 `chroma` 이미지를 1.5.9로 핀 설정하여 스키마 문제 원천 방지
  - `st.html` 컨테이너 높이를 강제 확보하도록 CSS `.copy-wrapper` 추가 및 JS 런타임 보정 코드 추가
  - `diagnose_db`를 read-only sqlite 조회(`collections`·`embeddings` 수 확인)로 전환 → 쓰기·락 경합·임베딩 모델 로드를 모두 제거(비루트 권한 오류 해소). 복원은 디스크 교체라 실행 중 서버 반영엔 재시작이 필요하므로, api 컨테이너에 docker 소켓 권한을 부여하지 않는 안전한 방식으로 운영자에게 상태(note)·UI로 재시작을 안내
* **결과**:
  - 복원 프로세스 정상 수행, Prod/Dev 컨테이너 정상 구동, UI 복사 버튼 노출 및 기능 정상 확인
  - 서버 가동 중에도 복원 후 진단이 권한 오류·락 경합 없이 통과, 복원 반영 경로(재시작) 안내 명확

## 테스트 결과 / 결과 증빙 (Screenshots / Logs)

* 로컬 API, App 컨테이너 정상 기동 및 DB 백업/복원 테스트 로그 확인 (Permission Error 완전 해소).
* requirements 패키지 정상 인스톨 및 경고 메시지 출력 해소.
* `diagnose_db` read-only 전환 실측: chromadb 서버 가동 중 진단 통과(컬렉션 1·임베딩 1251건, 락 오류 없음).
* 단위테스트 정비: backup_manager·admin·restore_db 22개 통과(ruff 포함). CI lint·test SUCCESS.

## 셀프 체크리스트

* [x] develop 브랜치를 최신으로 반영(merge/rebase)했나요?
* [x] 불필요한 주석이나 테스트용 print문은 제거했나요?
* [x] 관련 이슈 번호를 연결했나요? (Resolves #209)
* [x] 주간 발표 자료로 활용 가능한 직관적인 결과물(스크린샷/로그)을 첨부했나요?
* [x] 기술적 도전 및 해결 과정(Narrative)을 작성했나요?

## 리뷰어에게 한마디

DB 백업/복원 로직의 도커 볼륨 마운트 권한/락 이슈와 프로덕션 배포 시 발생한 의존성 문제를 전부 잡았습니다. 복사 버튼 UI도 원래 크기로 돌려놨습니다.

추가로, 복원 후 자가진단이 비루트 컨테이너에서 임베딩 권한 오류(Errno 13)로 실패하고 임베디드 클라이언트가 chromadb 서버와 sqlite 파일 락을 경합하던 문제를 read-only sqlite 검증으로 전환해 함께 해결했습니다(임베딩 모델 로드도 불필요해짐). 복원은 디스크 파일을 교체하므로 실행 중 chromadb 서버에 반영하려면 재시작이 필요한데, api 컨테이너에 docker 소켓 권한을 주지 않기 위해 자동 재시작 대신 운영자 수동 재시작 + UI/로그 안내 방식을 택했습니다. 확인 부탁드려요!

Resolves #209
